### PR TITLE
Add TL005: Static Expression Property Analyzer

### DIFF
--- a/.github/prompts/analyzer.prompt.md
+++ b/.github/prompts/analyzer.prompt.md
@@ -1,5 +1,6 @@
 ---
 mode: agent
+tools: [anzlyerToolSet]
 ---
 
 # Roslyn Analyzer and Code Fix Expert

--- a/.github/prompts/analyzer.prompt.md
+++ b/.github/prompts/analyzer.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: agent
-tools: [anzlyerToolSet]
+tools: [analyzerToolSet]
 ---
 
 # Roslyn Analyzer and Code Fix Expert

--- a/misc/ISSUE_15_IMPLEMENTATION_PLAN.md
+++ b/misc/ISSUE_15_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,272 @@
+# Issue #15 Implementation Plan: Static Expression Property Analyzer
+
+## Overview
+**Issue:** [#15 - Analyzer: Avoid static => new pattern](https://github.com/Treit/ToListinator/issues/15)
+**Diagnostic ID:** TL005
+**Priority:** Medium
+**Estimated Effort:** 4-5 days
+
+## Problem Statement
+Create a Roslyn analyzer and code fix to detect static properties using expression body syntax (`=>`) that create new instances on every access, causing unnecessary allocations. The analyzer should suggest converting to getter-only properties with initialization.
+
+## Target Anti-Patterns
+
+### Pattern 1: Method Calls That May Allocate
+```csharp
+// ❌ BAD - calls method every access
+public static string? RoleInstance => Environment.GetEnvironmentVariable("MONITORING_ROLE_INSTANCE");
+
+// ✅ GOOD - calls once, caches result
+public static string? RoleInstance { get; } = Environment.GetEnvironmentVariable("MONITORING_ROLE_INSTANCE");
+```
+
+### Pattern 2: New Collection Creation
+```csharp
+// ❌ BAD - allocates new collection every access
+public static HashSet<string> Items => new HashSet<string> { "A", "B", "C" };
+
+// ✅ GOOD - creates once, caches
+public static HashSet<string> Items { get; } = new HashSet<string> { "A", "B", "C" };
+```
+
+### Pattern 3: Complex Expressions That Allocate
+```csharp
+// ❌ BAD - processes every access
+public static string[] Parts => "a,b,c".Split(',');
+
+// ✅ GOOD - processes once
+public static string[] Parts { get; } = "a,b,c".Split(',');
+```
+
+## Implementation Components
+
+### 1. Analyzer: `StaticExpressionPropertyAnalyzer.cs`
+**Location:** `src/ToListinator.Analyzers/StaticExpressionPropertyAnalyzer.cs`
+
+```csharp
+// Key implementation details:
+public const string DiagnosticId = "TL005";
+private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+    id: "TL005",
+    title: "Avoid static property expression bodies that create new instances",
+    messageFormat: "Static property '{0}' uses expression body syntax that may allocate on every access. Consider using getter-only property initialization instead.",
+    category: "Performance",
+    defaultSeverity: DiagnosticSeverity.Warning,
+    isEnabledByDefault: true);
+```
+
+**Analysis Strategy:**
+- Register for `SyntaxKind.PropertyDeclaration`
+- Use `RegisterCompilationStartAction` for performance
+- Check for static properties with expression bodies
+- Analyze expressions for allocation patterns
+
+**Detection Logic:**
+1. Property must be `static`
+2. Property must use expression body syntax (`=>`)
+3. Expression must contain potentially allocating operations:
+   - `new` expressions
+   - Method calls (except pure/cached methods)
+   - Collection initializers
+   - String operations that allocate
+
+### 2. Code Fix: `StaticExpressionPropertyCodeFixProvider.cs`
+**Location:** `src/ToListinator.CodeFixes/StaticExpressionPropertyCodeFixProvider.cs`
+
+**Transformation Logic:**
+```csharp
+// Transform from:
+public static Type Property => expression;
+
+// To:
+public static Type Property { get; } = expression;
+```
+
+**Implementation Requirements:**
+- Preserve all trivia (comments, formatting)
+- Handle complex expressions safely
+- Support fix-all scenarios
+- Maintain semantic equivalence
+
+### 3. Test Suite
+
+#### Analyzer Tests: `StaticExpressionPropertyAnalyzerTests.cs`
+**Location:** `test/ToListinator.Tests/StaticExpressionPropertyAnalyzerTests.cs`
+
+**Positive Test Cases (Should Trigger):**
+```csharp
+// Environment method calls
+public static string? EnvVar => Environment.GetEnvironmentVariable("KEY");
+
+// Object creation
+public static HashSet<string> Items => new HashSet<string> { "A", "B" };
+public static List<int> Numbers => new List<int> { 1, 2, 3 };
+public static Dictionary<string, int> Map => new Dictionary<string, int>();
+
+// String operations that allocate
+public static string[] Split => "a,b,c".Split(',');
+public static string Upper => "hello".ToUpper();
+
+// LINQ operations
+public static IEnumerable<int> Filtered => data.Where(x => x > 0);
+```
+
+**Negative Test Cases (Should NOT Trigger):**
+```csharp
+// Non-static properties
+public string Instance => "value";
+
+// Already cached properties  
+public static string Cached { get; } = "value";
+
+// Simple literals/constants
+public static string Literal => "constant";
+public static int Number => 42;
+public static bool Flag => true;
+
+// Static field references
+private static readonly string _field = "value";
+public static string Property => _field;
+
+// Pure expressions (no allocation)
+public static int Calculate => 5 + 3;
+public static string Combine => "a" + "b"; // compiler optimizes
+```
+
+#### Code Fix Tests: `StaticExpressionPropertyCodeFixTests.cs`
+**Location:** `test/ToListinator.Tests/StaticExpressionPropertyCodeFixTests.cs`
+
+**Test Scenarios:**
+1. Basic property transformations
+2. Properties with XML documentation
+3. Properties with attributes
+4. Multi-line expressions
+5. Complex formatting preservation
+6. Fix-all scenarios (multiple properties)
+
+## Project Updates Required
+
+### 1. Release Notes Update
+**File:** `src/ToListinator.Analyzers/AnalyzerReleases.Unshipped.md`
+
+```markdown
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+TL003   | Performance | Warning | Replace ToList().Count comparisons with Any() to avoid unnecessary allocation
+TL004   | Performance | Warning | Avoid foreach with null coalescing to empty collection
+TL005   | Performance | Warning | Avoid static property expression bodies that create new instances
+```
+
+### 2. Test Project References
+Ensure new analyzer and code fix are properly referenced in test projects.
+
+## Implementation Phases
+
+### Phase 1: Core Analyzer (Day 1)
+- [ ] Create `StaticExpressionPropertyAnalyzer.cs`
+- [ ] Implement basic detection for `new` expressions
+- [ ] Add diagnostic descriptor with TL005 ID
+- [ ] Create basic positive/negative test cases
+- [ ] Verify analyzer triggers correctly
+
+### Phase 2: Code Fix Provider (Day 2)
+- [ ] Create `StaticExpressionPropertyCodeFixProvider.cs`
+- [ ] Implement basic transformation logic
+- [ ] Handle syntax tree manipulation safely
+- [ ] Create code fix test cases
+- [ ] Verify transformations are correct
+
+### Phase 3: Enhanced Detection (Day 3)
+- [ ] Add method call analysis for allocation detection
+- [ ] Implement collection creation pattern recognition
+- [ ] Add LINQ operation detection
+- [ ] Enhance edge case handling
+- [ ] Add comprehensive test coverage
+
+### Phase 4: Advanced Features (Day 4)
+- [ ] Implement fix-all scenarios
+- [ ] Add complex formatting preservation
+- [ ] Handle properties with attributes/documentation
+- [ ] Add performance optimizations
+- [ ] Test integration with existing analyzers
+
+### Phase 5: Polish & Integration (Day 5)
+- [ ] Update release documentation
+- [ ] Run full test suite
+- [ ] Performance testing
+- [ ] Integration testing with real codebases
+- [ ] Final code review and cleanup
+
+## Technical Considerations
+
+### Detection Sophistication
+1. **Method Purity Analysis:** Distinguish between pure methods and allocating methods
+2. **Type System Integration:** Use semantic model for accurate type analysis
+3. **Expression Complexity:** Handle nested expressions and complex syntax trees
+4. **False Positive Avoidance:** Carefully tune detection to avoid noise
+
+### Performance Optimizations
+1. **Symbol Caching:** Cache type symbols in compilation start action
+2. **Efficient Traversal:** Minimize syntax tree walking
+3. **Lazy Evaluation:** Only perform expensive analysis when necessary
+4. **Memory Management:** Avoid allocations in analyzer hot paths
+
+### Code Fix Robustness
+1. **Trivia Preservation:** Maintain all formatting, comments, and whitespace
+2. **Syntax Validation:** Ensure generated code compiles correctly
+3. **Semantic Preservation:** Maintain exact semantic behavior
+4. **Error Recovery:** Handle malformed or unusual syntax gracefully
+
+## Success Criteria
+
+- [ ] **Accuracy:** Analyzer correctly identifies target patterns with <1% false positive rate
+- [ ] **Completeness:** Code fix handles all detected patterns correctly
+- [ ] **Performance:** Analyzer adds <50ms to compilation time for typical projects  
+- [ ] **Integration:** Works seamlessly with existing ToListinator analyzers
+- [ ] **Testing:** Achieves >95% code coverage with comprehensive test suite
+- [ ] **Documentation:** All changes properly documented following project conventions
+
+## Risk Mitigation
+
+### High Risk: False Positives
+- **Mitigation:** Extensive testing with real codebases, conservative detection rules
+- **Validation:** Manual review of analyzer results on large projects
+
+### Medium Risk: Complex Code Fix Scenarios
+- **Mitigation:** Incremental implementation, robust trivia handling
+- **Validation:** Test complex formatting scenarios extensively
+
+### Low Risk: Performance Impact
+- **Mitigation:** Performance testing, efficient implementation patterns
+- **Validation:** Benchmark against existing analyzers
+
+## Notes for Implementation
+
+1. **Follow Existing Patterns:** Use the same structure as `ToListForEachAnalyzer` and `IdentitySelectAnalyzer`
+2. **Test-Driven Development:** Write tests first, then implement to satisfy them
+3. **Incremental Approach:** Start simple, add complexity gradually
+4. **Code Review:** Follow all patterns from `analyzer.prompt.md` instructions
+5. **Integration Testing:** Test with `ToListinator.TestApp` for real-world validation
+
+## Files to Create/Modify
+
+### New Files:
+- `src/ToListinator.Analyzers/StaticExpressionPropertyAnalyzer.cs`
+- `src/ToListinator.CodeFixes/StaticExpressionPropertyCodeFixProvider.cs`
+- `test/ToListinator.Tests/StaticExpressionPropertyAnalyzerTests.cs`
+- `test/ToListinator.Tests/StaticExpressionPropertyCodeFixTests.cs`
+
+### Modified Files:
+- `src/ToListinator.Analyzers/AnalyzerReleases.Unshipped.md`
+
+### Validation Files:
+- Test with existing projects in `test/ToListinator.TestApp/`
+- Integration test in `test/RoslynPlayground/` if needed
+
+---
+
+**Plan Created:** August 3, 2025
+**Estimated Completion:** 4-5 development days
+**Ready for Implementation:** Yes

--- a/src/ToListinator.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/ToListinator.Analyzers/AnalyzerReleases.Unshipped.md
@@ -4,3 +4,4 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 TL003   | Performance | Warning | Replace ToList().Count comparisons with Any() to avoid unnecessary allocation
 TL004   | Performance | Warning | Avoid foreach with null coalescing to empty collection
+TL005   | Performance | Warning | Avoid static property expression bodies that create new instances

--- a/src/ToListinator.Analyzers/StaticExpressionPropertyAnalyzer.cs
+++ b/src/ToListinator.Analyzers/StaticExpressionPropertyAnalyzer.cs
@@ -1,0 +1,149 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace ToListinator.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class StaticExpressionPropertyAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "TL005";
+    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+        id: "TL005",
+        title: "Avoid static property expression bodies that create new instances",
+        messageFormat: "Static property '{0}' uses expression body syntax that may allocate on every access. Use a getter-only property with an initializer, or convert to a method call.",
+        category: "Performance",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => [Rule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzePropertyDeclaration, SyntaxKind.PropertyDeclaration);
+    }
+
+    private static void AnalyzePropertyDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
+
+        // Must be static
+        if (!propertyDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword))
+        {
+            return;
+        }
+
+        // Must have expression body (=>)
+        if (propertyDeclaration.ExpressionBody == null)
+        {
+            return;
+        }
+
+        // Analyze the expression for potentially allocating operations
+        var expression = propertyDeclaration.ExpressionBody.Expression;
+        if (ContainsPotentialAllocation(expression, context.SemanticModel))
+        {
+            var diagnostic = Diagnostic.Create(
+                Rule,
+                propertyDeclaration.Identifier.GetLocation(),
+                propertyDeclaration.Identifier.ValueText);
+
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+
+    private static bool ContainsPotentialAllocation(ExpressionSyntax expression, SemanticModel semanticModel)
+    {
+        return expression switch
+        {
+            // Object creation expressions: new Foo(), new[] { ... }, new List<T> { ... }
+            ObjectCreationExpressionSyntax => true,
+            ImplicitObjectCreationExpressionSyntax => true,
+            ArrayCreationExpressionSyntax => true,
+            ImplicitArrayCreationExpressionSyntax => true,
+            CollectionExpressionSyntax => true,
+
+            // Method invocations that may allocate
+            InvocationExpressionSyntax invocation => IsAllocatingMethodCall(invocation, semanticModel),
+
+            // Member access expressions - check the expression being accessed
+            MemberAccessExpressionSyntax memberAccess => ContainsPotentialAllocation(memberAccess.Expression, semanticModel),
+
+            // Conditional expressions - check both branches
+            ConditionalExpressionSyntax conditional =>
+                ContainsPotentialAllocation(conditional.WhenTrue, semanticModel) ||
+                ContainsPotentialAllocation(conditional.WhenFalse, semanticModel),
+
+            // Binary expressions - check both operands (for string concatenation, null coalescing, etc.)
+            BinaryExpressionSyntax binary =>
+                (binary.IsKind(SyntaxKind.AddExpression) && IsStringConcatenation(binary, semanticModel)) ||
+                binary.IsKind(SyntaxKind.CoalesceExpression) && ContainsPotentialAllocation(binary.Left, semanticModel) ||
+                ContainsPotentialAllocation(binary.Left, semanticModel) ||
+                ContainsPotentialAllocation(binary.Right, semanticModel),
+
+            // Parenthesized expressions - check the inner expression
+            ParenthesizedExpressionSyntax parenthesized =>
+                ContainsPotentialAllocation(parenthesized.Expression, semanticModel),
+
+            // Cast expressions - check the expression being cast
+            CastExpressionSyntax cast =>
+                ContainsPotentialAllocation(cast.Expression, semanticModel),
+
+            // Literals, identifiers, and other simple expressions don't allocate
+            _ => false
+        };
+    }
+
+    private static bool IsAllocatingMethodCall(InvocationExpressionSyntax invocation, SemanticModel semanticModel)
+    {
+        var symbolInfo = semanticModel.GetSymbolInfo(invocation);
+        if (symbolInfo.Symbol is not IMethodSymbol method)
+        {
+            return false;
+        }
+
+        // Environment method calls are likely allocating
+        if (method.ContainingType.Name == "Environment" && 
+            method.ContainingType.ContainingNamespace.ToDisplayString() == "System")
+        {
+            return true;
+        }
+
+        // String methods that allocate
+        if (method.ContainingType.SpecialType == SpecialType.System_String)
+        {
+            return method.Name is "Split" or "ToUpper" or "ToLower" or "Trim" or "TrimStart" or "TrimEnd" 
+                or "Substring" or "Replace" or "Remove" or "Insert" or "PadLeft" or "PadRight";
+        }
+
+        // LINQ methods typically allocate
+        if (method.ContainingType.Name == "Enumerable" && 
+            method.ContainingType.ContainingNamespace.ToDisplayString() == "System.Linq")
+        {
+            return true;
+        }
+
+        // Collection methods that may allocate
+        if (method.Name is "ToArray" or "ToList" or "ToDictionary" or "ToHashSet")
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsStringConcatenation(BinaryExpressionSyntax binary, SemanticModel semanticModel)
+    {
+        var leftType = semanticModel.GetTypeInfo(binary.Left).Type;
+        var rightType = semanticModel.GetTypeInfo(binary.Right).Type;
+        
+        return leftType?.SpecialType == SpecialType.System_String ||
+               rightType?.SpecialType == SpecialType.System_String;
+    }
+}

--- a/src/ToListinator.Analyzers/StaticExpressionPropertyAnalyzer.cs
+++ b/src/ToListinator.Analyzers/StaticExpressionPropertyAnalyzer.cs
@@ -72,13 +72,21 @@ public class StaticExpressionPropertyAnalyzer : DiagnosticAnalyzer
             // Method invocations that may allocate
             InvocationExpressionSyntax invocation => IsAllocatingMethodCall(invocation, semanticModel),
 
+            // Assignment expressions - check the right side (e.g., _ = new HashSet())
+            // Exception: null-coalescing assignment (??=) is lazy initialization and should not be flagged
+            AssignmentExpressionSyntax assignment =>
+                !assignment.IsKind(SyntaxKind.CoalesceAssignmentExpression) &&
+                ContainsPotentialAllocation(assignment.Right, semanticModel),
+
             // Member access expressions - check the expression being accessed
             MemberAccessExpressionSyntax memberAccess => ContainsPotentialAllocation(memberAccess.Expression, semanticModel),
 
             // Conditional expressions - check both branches
+            // Exception: lazy initialization patterns like "field is not null ? field : new Obj()" should not be flagged
             ConditionalExpressionSyntax conditional =>
-                ContainsPotentialAllocation(conditional.WhenTrue, semanticModel) ||
-                ContainsPotentialAllocation(conditional.WhenFalse, semanticModel),
+                !IsLazyInitializationPattern(conditional) &&
+                (ContainsPotentialAllocation(conditional.WhenTrue, semanticModel) ||
+                ContainsPotentialAllocation(conditional.WhenFalse, semanticModel)),
 
             // Binary expressions - check both operands (for string concatenation, null coalescing, etc.)
             BinaryExpressionSyntax binary =>
@@ -109,7 +117,7 @@ public class StaticExpressionPropertyAnalyzer : DiagnosticAnalyzer
         }
 
         // Environment method calls are likely allocating
-        if (method.ContainingType.Name == "Environment" && 
+        if (method.ContainingType.Name == "Environment" &&
             method.ContainingType.ContainingNamespace.ToDisplayString() == "System")
         {
             return true;
@@ -118,12 +126,12 @@ public class StaticExpressionPropertyAnalyzer : DiagnosticAnalyzer
         // String methods that allocate
         if (method.ContainingType.SpecialType == SpecialType.System_String)
         {
-            return method.Name is "Split" or "ToUpper" or "ToLower" or "Trim" or "TrimStart" or "TrimEnd" 
+            return method.Name is "Split" or "ToUpper" or "ToLower" or "Trim" or "TrimStart" or "TrimEnd"
                 or "Substring" or "Replace" or "Remove" or "Insert" or "PadLeft" or "PadRight";
         }
 
         // LINQ methods typically allocate
-        if (method.ContainingType.Name == "Enumerable" && 
+        if (method.ContainingType.Name == "Enumerable" &&
             method.ContainingType.ContainingNamespace.ToDisplayString() == "System.Linq")
         {
             return true;
@@ -145,8 +153,75 @@ public class StaticExpressionPropertyAnalyzer : DiagnosticAnalyzer
     {
         var leftType = semanticModel.GetTypeInfo(binary.Left).Type;
         var rightType = semanticModel.GetTypeInfo(binary.Right).Type;
-        
+
         return leftType?.SpecialType == SpecialType.System_String ||
                rightType?.SpecialType == SpecialType.System_String;
+    }
+
+    private static bool IsLazyInitializationPattern(ConditionalExpressionSyntax conditional)
+    {
+        // Check if this is a lazy initialization pattern like:
+        // field is not null ? field : new Obj()
+        // field != null ? field : new Obj()
+
+        // The condition should be a null check
+        if (!IsNullCheck(conditional.Condition))
+        {
+            return false;
+        }
+
+        // The true branch should be a simple identifier (the field)
+        if (conditional.WhenTrue is not IdentifierNameSyntax trueIdentifier)
+        {
+            return false;
+        }
+
+        // If the condition is checking that a field is not null,
+        // and the true branch returns that same field, this is likely lazy initialization
+        var checkedFieldName = GetFieldNameFromNullCheck(conditional.Condition);
+        return checkedFieldName != null && checkedFieldName == trueIdentifier.Identifier.ValueText;
+    }
+
+    private static bool IsNullCheck(ExpressionSyntax condition)
+    {
+        return condition switch
+        {
+            // Pattern: field is not null
+            IsPatternExpressionSyntax isPattern when isPattern.Pattern is UnaryPatternSyntax unaryPattern &&
+                unaryPattern.Pattern is ConstantPatternSyntax constantPattern &&
+                constantPattern.Expression.IsKind(SyntaxKind.NullLiteralExpression) => true,
+
+            // Pattern: field != null
+            BinaryExpressionSyntax binary when binary.IsKind(SyntaxKind.NotEqualsExpression) &&
+                (binary.Left.IsKind(SyntaxKind.NullLiteralExpression) || binary.Right.IsKind(SyntaxKind.NullLiteralExpression)) => true,
+
+            // Pattern: field == null (inverted logic, but still a null check)
+            BinaryExpressionSyntax binary2 when binary2.IsKind(SyntaxKind.EqualsExpression) &&
+                (binary2.Left.IsKind(SyntaxKind.NullLiteralExpression) || binary2.Right.IsKind(SyntaxKind.NullLiteralExpression)) => true,
+
+            _ => false
+        };
+    }
+
+    private static string? GetFieldNameFromNullCheck(ExpressionSyntax condition)
+    {
+        return condition switch
+        {
+            // Pattern: field is not null
+            IsPatternExpressionSyntax isPattern when isPattern.Expression is IdentifierNameSyntax identifier =>
+                identifier.Identifier.ValueText,
+
+            // Pattern: field != null
+            BinaryExpressionSyntax binary when binary.IsKind(SyntaxKind.NotEqualsExpression) =>
+                binary.Left is IdentifierNameSyntax leftId ? leftId.Identifier.ValueText :
+                binary.Right is IdentifierNameSyntax rightId ? rightId.Identifier.ValueText : null,
+
+            // Pattern: field == null (inverted, but we can still extract the field name)
+            BinaryExpressionSyntax binary2 when binary2.IsKind(SyntaxKind.EqualsExpression) =>
+                binary2.Left is IdentifierNameSyntax leftId2 ? leftId2.Identifier.ValueText :
+                binary2.Right is IdentifierNameSyntax rightId2 ? rightId2.Identifier.ValueText : null,
+
+            _ => null
+        };
     }
 }

--- a/src/ToListinator.Analyzers/StaticExpressionPropertyAnalyzer.cs
+++ b/src/ToListinator.Analyzers/StaticExpressionPropertyAnalyzer.cs
@@ -130,7 +130,10 @@ public class StaticExpressionPropertyAnalyzer : DiagnosticAnalyzer
         }
 
         // Collection methods that may allocate
-        if (method.Name is "ToArray" or "ToList" or "ToDictionary" or "ToHashSet" or "ToFrozenSet")
+        if (method.Name is "ToArray" or "ToList" or "ToDictionary" or "ToHashSet" or "ToFrozenSet"
+            or "ToLookup" or "ToFrozenDictionary" or "ToImmutableArray" or "ToImmutableList"
+            or "ToImmutableHashSet" or "ToImmutableDictionary" or "ToImmutableSortedSet"
+            or "ToImmutableSortedDictionary")
         {
             return true;
         }

--- a/src/ToListinator.Analyzers/StaticExpressionPropertyAnalyzer.cs
+++ b/src/ToListinator.Analyzers/StaticExpressionPropertyAnalyzer.cs
@@ -130,7 +130,7 @@ public class StaticExpressionPropertyAnalyzer : DiagnosticAnalyzer
         }
 
         // Collection methods that may allocate
-        if (method.Name is "ToArray" or "ToList" or "ToDictionary" or "ToHashSet")
+        if (method.Name is "ToArray" or "ToList" or "ToDictionary" or "ToHashSet" or "ToFrozenSet")
         {
             return true;
         }

--- a/src/ToListinator.CodeFixes/StaticExpressionPropertyCodeFixProvider.cs
+++ b/src/ToListinator.CodeFixes/StaticExpressionPropertyCodeFixProvider.cs
@@ -1,0 +1,87 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ToListinator.Analyzers;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace ToListinator.CodeFixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(StaticExpressionPropertyCodeFixProvider)), Shared]
+public class StaticExpressionPropertyCodeFixProvider : CodeFixProvider
+{
+    public sealed override ImmutableArray<string> FixableDiagnosticIds
+        => [StaticExpressionPropertyAnalyzer.DiagnosticId];
+
+    public sealed override FixAllProvider GetFixAllProvider()
+        => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root == null) return;
+
+        var diagnostic = context.Diagnostics.FirstOrDefault(d => d.Id == StaticExpressionPropertyAnalyzer.DiagnosticId);
+        if (diagnostic == null) return;
+
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+        var property = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf()
+            .OfType<PropertyDeclarationSyntax>()
+            .FirstOrDefault();
+
+        if (property?.ExpressionBody == null) return;
+
+        var action = CodeAction.Create(
+            title: "Convert to getter-only property with initializer",
+            createChangedDocument: c => ConvertToGetterOnlyProperty(context.Document, property, c),
+            equivalenceKey: "ConvertToGetterOnlyProperty");
+
+        context.RegisterCodeFix(action, diagnostic);
+    }
+
+    private static async Task<Document> ConvertToGetterOnlyProperty(
+        Document document,
+        PropertyDeclarationSyntax property,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root == null) return document;
+
+        // Get the expression from the expression body
+        var expression = property.ExpressionBody!.Expression;
+
+        // Create the new property with getter-only accessor and initializer
+        var newProperty = property
+            .WithExpressionBody(null) // Remove expression body
+            .WithSemicolonToken(default) // Remove semicolon
+            .WithAccessorList(
+                AccessorList(
+                    SingletonList(
+                        AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
+                    )
+                )
+                .WithOpenBraceToken(Token(SyntaxKind.OpenBraceToken).WithTrailingTrivia(Space))
+                .WithCloseBraceToken(Token(SyntaxKind.CloseBraceToken))
+            )
+            .WithInitializer(
+                EqualsValueClause(expression)
+                    .WithEqualsToken(Token(SyntaxKind.EqualsToken).WithLeadingTrivia(Space).WithTrailingTrivia(Space))
+            )
+            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
+
+        // Preserve trivia from the original property
+        newProperty = newProperty
+            .WithLeadingTrivia(property.GetLeadingTrivia())
+            .WithTrailingTrivia(property.GetTrailingTrivia());
+
+        var newRoot = root.ReplaceNode(property, newProperty);
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/test/ToListinator.TestApp/TestSelect.cs
+++ b/test/ToListinator.TestApp/TestSelect.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Frozen;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -11,6 +12,9 @@ public class TestCode
 
     // Test with ReadOnlySet
     public static ReadOnlySet<string> Data3 => new ReadOnlySet<string>(Data2);
+
+    // Test with FrozenSet
+    public static FrozenSet<string> Data4 => _data!.ToFrozenSet();
 
     public void Test()
     {

--- a/test/ToListinator.TestApp/TestSelect.cs
+++ b/test/ToListinator.TestApp/TestSelect.cs
@@ -3,6 +3,11 @@ using System.Linq;
 
 public class TestCode
 {
+    static HashSet<string>? _data = null;
+    public static HashSet<string> Data => new HashSet<string> { "A", "B", "C" };
+
+    public static HashSet<string> Data2 => _data ??= new HashSet<string> { "A", "B", "C" };
+
     public void Test()
     {
         var numbers = new[] { 1, 2, 3 };
@@ -18,10 +23,9 @@ public class TestCode
             Print(num); // Output!
         }
 
-    }
-
-    void Print(int x)
-    {
-        Console.WriteLine(x);
+        void Print(int x)
+        {
+            Console.WriteLine(x);
+        }
     }
 }

--- a/test/ToListinator.TestApp/TestSelect.cs
+++ b/test/ToListinator.TestApp/TestSelect.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 public class TestCode
@@ -7,6 +8,9 @@ public class TestCode
     public static HashSet<string> Data => new HashSet<string> { "A", "B", "C" };
 
     public static HashSet<string> Data2 => _data ??= new HashSet<string> { "A", "B", "C" };
+
+    // Test with ReadOnlySet
+    public static ReadOnlySet<string> Data3 => new ReadOnlySet<string>(Data2);
 
     public void Test()
     {

--- a/test/ToListinator.Tests/Helpers/TestHelper.cs
+++ b/test/ToListinator.Tests/Helpers/TestHelper.cs
@@ -74,4 +74,30 @@ public static class TestHelper
 
         return test;
     }
+
+    public static CSharpAnalyzerTest<TAnalyzer, DefaultVerifier> CreateAnalyzerTest<TAnalyzer>(
+        [StringSyntax("c#-test")] string source,
+        DiagnosticResult expectedDiagnostic
+    )
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        var test = CreateAnalyzerTest<TAnalyzer>(source);
+        test.ExpectedDiagnostics.Add(expectedDiagnostic);
+        return test;
+    }
+
+    public static DiagnosticResult CreateDiagnostic(string diagnosticId)
+    {
+        return new DiagnosticResult(diagnosticId, Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
+    }
+
+    public static DiagnosticResult CreateDiagnostic(string diagnosticId, params string[] arguments)
+    {
+        var result = new DiagnosticResult(diagnosticId, Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
+        if (arguments.Length > 0)
+        {
+            result = result.WithArguments(arguments);
+        }
+        return result;
+    }
 }

--- a/test/ToListinator.Tests/Helpers/TestHelper.cs
+++ b/test/ToListinator.Tests/Helpers/TestHelper.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace ToListinator.Tests;
 
-public static class CodeFixTestHelper
+public static class TestHelper
 {
     private const string EditorConfig = """
         root = true
@@ -45,6 +45,33 @@ public static class CodeFixTestHelper
             },
         };
 
+        // Add .NET 8 reference assemblies to support FrozenSet and other newer types
+        csTest.TestState.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+        csTest.FixedState.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+
         return csTest;
+    }
+
+    public static CSharpAnalyzerTest<TAnalyzer, DefaultVerifier> CreateAnalyzerTest<TAnalyzer>(
+        [StringSyntax("c#-test")] string source
+    )
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        var test = new CSharpAnalyzerTest<TAnalyzer, DefaultVerifier>
+        {
+            TestState =
+            {
+                Sources = { source },
+                AnalyzerConfigFiles =
+                {
+                    { ("/.editorconfig", EditorConfig) },
+                },
+            },
+        };
+
+        // Add .NET 8 reference assemblies to support FrozenSet and other newer types
+        test.TestState.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+
+        return test;
     }
 }

--- a/test/ToListinator.Tests/IdentitySelectAnalyzerTests.cs
+++ b/test/ToListinator.Tests/IdentitySelectAnalyzerTests.cs
@@ -1,8 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
-    ToListinator.Analyzers.IdentitySelectAnalyzer,
-    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+using ToListinator.Analyzers;
 
 namespace ToListinator.Tests;
 
@@ -26,8 +23,11 @@ public class IdentitySelectAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<IdentitySelectAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL002").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -48,8 +48,11 @@ public class IdentitySelectAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<IdentitySelectAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL002").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -70,8 +73,11 @@ public class IdentitySelectAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<IdentitySelectAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL002").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -92,7 +98,8 @@ public class IdentitySelectAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<IdentitySelectAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -114,7 +121,8 @@ public class IdentitySelectAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<IdentitySelectAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -140,7 +148,8 @@ public class IdentitySelectAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<IdentitySelectAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -164,6 +173,7 @@ public class IdentitySelectAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<IdentitySelectAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
     }
 }

--- a/test/ToListinator.Tests/IdentitySelectCodeFixTests.cs
+++ b/test/ToListinator.Tests/IdentitySelectCodeFixTests.cs
@@ -42,7 +42,7 @@ public class IdentitySelectCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<IdentitySelectAnalyzer, IdentitySelectCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<IdentitySelectAnalyzer, IdentitySelectCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -85,7 +85,7 @@ public class IdentitySelectCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<IdentitySelectAnalyzer, IdentitySelectCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<IdentitySelectAnalyzer, IdentitySelectCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -128,7 +128,7 @@ public class IdentitySelectCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<IdentitySelectAnalyzer, IdentitySelectCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<IdentitySelectAnalyzer, IdentitySelectCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -178,7 +178,7 @@ public class IdentitySelectCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<IdentitySelectAnalyzer, IdentitySelectCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<IdentitySelectAnalyzer, IdentitySelectCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -223,7 +223,7 @@ public class IdentitySelectCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<IdentitySelectAnalyzer, IdentitySelectCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<IdentitySelectAnalyzer, IdentitySelectCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -268,7 +268,7 @@ public class IdentitySelectCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<IdentitySelectAnalyzer, IdentitySelectCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<IdentitySelectAnalyzer, IdentitySelectCodeFixProvider>(
             testCode,
             fixedCode
         );

--- a/test/ToListinator.Tests/NullCoalescingForeachAnalyzerTests.cs
+++ b/test/ToListinator.Tests/NullCoalescingForeachAnalyzerTests.cs
@@ -1,9 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-
-using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
-    ToListinator.Analyzers.NullCoalescingForeachAnalyzer,
-    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+using ToListinator.Analyzers;
 
 namespace ToListinator.Tests;
 
@@ -29,8 +25,11 @@ public class NullCoalescingForeachAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<NullCoalescingForeachAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL004").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -53,8 +52,11 @@ public class NullCoalescingForeachAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<NullCoalescingForeachAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL004").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -78,8 +80,11 @@ public class NullCoalescingForeachAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<NullCoalescingForeachAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL004").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -101,8 +106,11 @@ public class NullCoalescingForeachAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<NullCoalescingForeachAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL004").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -124,8 +132,11 @@ public class NullCoalescingForeachAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<NullCoalescingForeachAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL004").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -148,7 +159,8 @@ public class NullCoalescingForeachAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<NullCoalescingForeachAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -172,7 +184,8 @@ public class NullCoalescingForeachAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<NullCoalescingForeachAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -194,7 +207,8 @@ public class NullCoalescingForeachAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<NullCoalescingForeachAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -216,6 +230,7 @@ public class NullCoalescingForeachAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<NullCoalescingForeachAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
     }
 }

--- a/test/ToListinator.Tests/NullCoalescingForeachCodeFixTests.cs
+++ b/test/ToListinator.Tests/NullCoalescingForeachCodeFixTests.cs
@@ -45,7 +45,7 @@ public class NullCoalescingForeachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<NullCoalescingForeachAnalyzer, NullCoalescingForeachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<NullCoalescingForeachAnalyzer, NullCoalescingForeachCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -91,7 +91,7 @@ public class NullCoalescingForeachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<NullCoalescingForeachAnalyzer, NullCoalescingForeachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<NullCoalescingForeachAnalyzer, NullCoalescingForeachCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -141,7 +141,7 @@ public class NullCoalescingForeachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<NullCoalescingForeachAnalyzer, NullCoalescingForeachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<NullCoalescingForeachAnalyzer, NullCoalescingForeachCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -187,7 +187,7 @@ public class NullCoalescingForeachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<NullCoalescingForeachAnalyzer, NullCoalescingForeachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<NullCoalescingForeachAnalyzer, NullCoalescingForeachCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -233,7 +233,7 @@ public class NullCoalescingForeachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<NullCoalescingForeachAnalyzer, NullCoalescingForeachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<NullCoalescingForeachAnalyzer, NullCoalescingForeachCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -285,7 +285,7 @@ public class NullCoalescingForeachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<NullCoalescingForeachAnalyzer, NullCoalescingForeachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<NullCoalescingForeachAnalyzer, NullCoalescingForeachCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -339,7 +339,7 @@ public class NullCoalescingForeachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<NullCoalescingForeachAnalyzer, NullCoalescingForeachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<NullCoalescingForeachAnalyzer, NullCoalescingForeachCodeFixProvider>(
             testCode,
             fixedCode
         );

--- a/test/ToListinator.Tests/StaticExpressionPropertyAnalyzerTests.cs
+++ b/test/ToListinator.Tests/StaticExpressionPropertyAnalyzerTests.cs
@@ -1,9 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 using ToListinator.Analyzers;
-using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
-    ToListinator.Analyzers.StaticExpressionPropertyAnalyzer,
-    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace ToListinator.Tests;
 
@@ -21,8 +17,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("RoleInstance");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "RoleInstance").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -37,8 +34,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Items");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Items").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -53,8 +51,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Numbers");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Numbers").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -69,8 +68,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Map");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Map").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -83,8 +83,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Parts");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Parts").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -97,8 +98,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Upper");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Upper").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -115,8 +117,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Filtered");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Filtered").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -133,8 +136,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("List");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "List").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -147,8 +151,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Array");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Array").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -161,7 +166,8 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        await test.RunAsync();
     }
 
     [Fact]
@@ -176,7 +182,8 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        await test.RunAsync();
     }
 
     [Fact]
@@ -189,7 +196,8 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        await test.RunAsync();
     }
 
     [Fact]
@@ -202,7 +210,8 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        await test.RunAsync();
     }
 
     [Fact]
@@ -215,7 +224,8 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        await test.RunAsync();
     }
 
     [Fact]
@@ -229,7 +239,8 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        await test.RunAsync();
     }
 
     [Fact]
@@ -242,7 +253,8 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        await test.RunAsync();
     }
 
     [Fact]
@@ -258,8 +270,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Conditional");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Conditional").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -273,7 +286,8 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        await test.RunAsync();
     }
 
     [Fact]
@@ -290,12 +304,10 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = new[]
-        {
-            Verify.Diagnostic().WithLocation(0).WithArguments("EnvVar"),
-            Verify.Diagnostic().WithLocation(1).WithArguments("Numbers")
-        };
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "EnvVar").WithLocation(0));
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Numbers").WithLocation(1));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -486,8 +498,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Data5");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Data5").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -503,7 +516,8 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        await test.RunAsync();
     }
 
     [Fact]
@@ -519,8 +533,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Data");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Data").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -536,8 +551,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Data");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Data").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -553,8 +569,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Data");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Data").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -570,8 +587,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Data");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Data").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -588,8 +606,9 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Data");
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Data").WithLocation(0));
+        await test.RunAsync();
     }
 
     [Fact]
@@ -605,7 +624,8 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        await test.RunAsync();
     }
 
     [Fact]
@@ -621,7 +641,8 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        await test.RunAsync();
     }
 
     [Fact]
@@ -637,6 +658,7 @@ public class StaticExpressionPropertyAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        await test.RunAsync();
     }
 }

--- a/test/ToListinator.Tests/StaticExpressionPropertyAnalyzerTests.cs
+++ b/test/ToListinator.Tests/StaticExpressionPropertyAnalyzerTests.cs
@@ -320,4 +320,157 @@ public class StaticExpressionPropertyAnalyzerTests
                 .WithArguments("Data4"));
         await test.RunAsync();
     }
+
+    [Fact]
+    public async Task ShouldReportWarningForToImmutableArray()
+    {
+        const string testCode = """
+        using System.Collections.Immutable;
+        using System.Linq;
+
+        public class TestClass
+        {
+            private static readonly int[] _data = { 1, 2, 3 };
+            public static ImmutableArray<int> {|#0:Numbers|} => _data.ToImmutableArray();
+        }
+        """;
+
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("TL005", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("Numbers"));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForToImmutableList()
+    {
+        const string testCode = """
+        using System.Collections.Immutable;
+        using System.Linq;
+
+        public class TestClass
+        {
+            private static readonly int[] _data = { 1, 2, 3 };
+            public static ImmutableList<int> {|#0:Numbers|} => _data.ToImmutableList();
+        }
+        """;
+
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("TL005", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("Numbers"));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForToImmutableHashSet()
+    {
+        const string testCode = """
+        using System.Collections.Immutable;
+        using System.Linq;
+
+        public class TestClass
+        {
+            private static readonly string[] _data = { "A", "B", "C" };
+            public static ImmutableHashSet<string> {|#0:Items|} => _data.ToImmutableHashSet();
+        }
+        """;
+
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("TL005", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("Items"));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForToImmutableDictionary()
+    {
+        const string testCode = """
+        using System.Collections.Immutable;
+        using System.Linq;
+
+        public class TestClass
+        {
+            private static readonly string[] _data = { "A", "B", "C" };
+            public static ImmutableDictionary<string, int> {|#0:Map|} => _data.ToImmutableDictionary(x => x, x => x.Length);
+        }
+        """;
+
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("TL005", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("Map"));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForToImmutableSortedSet()
+    {
+        const string testCode = """
+        using System.Collections.Immutable;
+        using System.Linq;
+
+        public class TestClass
+        {
+            private static readonly int[] _data = { 3, 1, 2 };
+            public static ImmutableSortedSet<int> {|#0:SortedNumbers|} => _data.ToImmutableSortedSet();
+        }
+        """;
+
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("TL005", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("SortedNumbers"));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForToImmutableSortedDictionary()
+    {
+        const string testCode = """
+        using System.Collections.Immutable;
+        using System.Linq;
+
+        public class TestClass
+        {
+            private static readonly string[] _data = { "C", "A", "B" };
+            public static ImmutableSortedDictionary<string, int> {|#0:SortedMap|} => _data.ToImmutableSortedDictionary(x => x, x => x.Length);
+        }
+        """;
+
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("TL005", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("SortedMap"));
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForToLookup()
+    {
+        const string testCode = """
+        using System.Linq;
+
+        public class TestClass
+        {
+            private static readonly string[] _data = { "Apple", "Banana", "Apricot" };
+            public static ILookup<char, string> {|#0:GroupedByFirstLetter|} => _data.ToLookup(x => x[0]);
+        }
+        """;
+
+        var test = TestHelper.CreateAnalyzerTest<StaticExpressionPropertyAnalyzer>(testCode);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("TL005", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("GroupedByFirstLetter"));
+        await test.RunAsync();
+    }
 }

--- a/test/ToListinator.Tests/StaticExpressionPropertyAnalyzerTests.cs
+++ b/test/ToListinator.Tests/StaticExpressionPropertyAnalyzerTests.cs
@@ -1,0 +1,299 @@
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+    ToListinator.Analyzers.StaticExpressionPropertyAnalyzer,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace ToListinator.Tests;
+
+public class StaticExpressionPropertyAnalyzerTests
+{
+    [Fact]
+    public async Task ShouldReportWarningForEnvironmentMethodCall()
+    {
+        const string testCode = """
+        using System;
+
+        public class TestClass
+        {
+            public static string? {|#0:RoleInstance|} => Environment.GetEnvironmentVariable("MONITORING_ROLE_INSTANCE");
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("RoleInstance");
+        await Verify.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForNewHashSetCreation()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            public static HashSet<string> {|#0:Items|} => new HashSet<string> { "A", "B", "C" };
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Items");
+        await Verify.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForNewListCreation()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            public static List<int> {|#0:Numbers|} => new List<int> { 1, 2, 3 };
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Numbers");
+        await Verify.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForNewDictionaryCreation()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            public static Dictionary<string, int> {|#0:Map|} => new Dictionary<string, int>();
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Map");
+        await Verify.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForStringSplit()
+    {
+        const string testCode = """
+        public class TestClass
+        {
+            public static string[] {|#0:Parts|} => "a,b,c".Split(',');
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Parts");
+        await Verify.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForStringToUpper()
+    {
+        const string testCode = """
+        public class TestClass
+        {
+            public static string {|#0:Upper|} => "hello".ToUpper();
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Upper");
+        await Verify.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForLinqWhere()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        public class TestClass
+        {
+            private static readonly int[] data = { 1, 2, 3, 4, 5 };
+            public static IEnumerable<int> {|#0:Filtered|} => data.Where(x => x > 0);
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Filtered");
+        await Verify.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForToList()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        public class TestClass
+        {
+            private static readonly int[] data = { 1, 2, 3, 4, 5 };
+            public static List<int> {|#0:List|} => data.ToList();
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("List");
+        await Verify.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForArrayCreation()
+    {
+        const string testCode = """
+        public class TestClass
+        {
+            public static int[] {|#0:Array|} => new int[] { 1, 2, 3 };
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Array");
+        await Verify.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+    [Fact]
+    public async Task ShouldNotReportWarningForNonStaticProperty()
+    {
+        const string testCode = """
+        public class TestClass
+        {
+            public string Instance => "value";
+        }
+        """;
+
+        await Verify.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task ShouldNotReportWarningForGetterOnlyProperty()
+    {
+        const string testCode = """
+        using System;
+
+        public class TestClass
+        {
+            public static string? Cached { get; } = Environment.GetEnvironmentVariable("KEY");
+        }
+        """;
+
+        await Verify.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task ShouldNotReportWarningForStringLiteral()
+    {
+        const string testCode = """
+        public class TestClass
+        {
+            public static string Literal => "constant";
+        }
+        """;
+
+        await Verify.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task ShouldNotReportWarningForIntegerLiteral()
+    {
+        const string testCode = """
+        public class TestClass
+        {
+            public static int Number => 42;
+        }
+        """;
+
+        await Verify.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task ShouldNotReportWarningForBooleanLiteral()
+    {
+        const string testCode = """
+        public class TestClass
+        {
+            public static bool Flag => true;
+        }
+        """;
+
+        await Verify.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task ShouldNotReportWarningForStaticFieldReference()
+    {
+        const string testCode = """
+        public class TestClass
+        {
+            private static readonly string _field = "value";
+            public static string Property => _field;
+        }
+        """;
+
+        await Verify.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task ShouldNotReportWarningForSimpleArithmetic()
+    {
+        const string testCode = """
+        public class TestClass
+        {
+            public static int Calculate => 5 + 3;
+        }
+        """;
+
+        await Verify.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForConditionalWithAllocation()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            private static readonly bool condition = true;
+            public static List<string> {|#0:Conditional|} => condition ? new List<string> { "yes" } : new List<string> { "no" };
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Conditional");
+        await Verify.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+    [Fact]
+    public async Task ShouldNotReportWarningForConditionalWithoutAllocation()
+    {
+        const string testCode = """
+        public class TestClass
+        {
+            private static readonly bool condition = true;
+            public static string Conditional => condition ? "yes" : "no";
+        }
+        """;
+
+        await Verify.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForMultipleViolations()
+    {
+        const string testCode = """
+        using System;
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            public static string? {|#0:EnvVar|} => Environment.GetEnvironmentVariable("KEY");
+            public static List<int> {|#1:Numbers|} => new List<int> { 1, 2, 3 };
+        }
+        """;
+
+        var expected = new[]
+        {
+            Verify.Diagnostic().WithLocation(0).WithArguments("EnvVar"),
+            Verify.Diagnostic().WithLocation(1).WithArguments("Numbers")
+        };
+        await Verify.VerifyAnalyzerAsync(testCode, expected);
+    }
+}

--- a/test/ToListinator.Tests/StaticExpressionPropertyCodeFixTests.cs
+++ b/test/ToListinator.Tests/StaticExpressionPropertyCodeFixTests.cs
@@ -1,9 +1,6 @@
-using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
-    ToListinator.Analyzers.StaticExpressionPropertyAnalyzer,
-    ToListinator.CodeFixes.StaticExpressionPropertyCodeFixProvider,
-    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+using ToListinator.Analyzers;
+using ToListinator.CodeFixes;
 
 namespace ToListinator.Tests;
 
@@ -30,8 +27,12 @@ public class StaticExpressionPropertyCodeFixTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("RoleInstance");
-        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        var test = TestHelper.CreateCodeFixTest<StaticExpressionPropertyAnalyzer, StaticExpressionPropertyCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "RoleInstance").WithLocation(0));
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -55,8 +56,12 @@ public class StaticExpressionPropertyCodeFixTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Items");
-        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        var test = TestHelper.CreateCodeFixTest<StaticExpressionPropertyAnalyzer, StaticExpressionPropertyCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Items").WithLocation(0));
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -80,8 +85,12 @@ public class StaticExpressionPropertyCodeFixTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Numbers");
-        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        var test = TestHelper.CreateCodeFixTest<StaticExpressionPropertyAnalyzer, StaticExpressionPropertyCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Numbers").WithLocation(0));
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -101,8 +110,12 @@ public class StaticExpressionPropertyCodeFixTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Parts");
-        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        var test = TestHelper.CreateCodeFixTest<StaticExpressionPropertyAnalyzer, StaticExpressionPropertyCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Parts").WithLocation(0));
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -132,8 +145,12 @@ public class StaticExpressionPropertyCodeFixTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Items");
-        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        var test = TestHelper.CreateCodeFixTest<StaticExpressionPropertyAnalyzer, StaticExpressionPropertyCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Items").WithLocation(0));
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -161,8 +178,12 @@ public class StaticExpressionPropertyCodeFixTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Items");
-        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        var test = TestHelper.CreateCodeFixTest<StaticExpressionPropertyAnalyzer, StaticExpressionPropertyCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Items").WithLocation(0));
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -186,8 +207,12 @@ public class StaticExpressionPropertyCodeFixTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Complex");
-        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        var test = TestHelper.CreateCodeFixTest<StaticExpressionPropertyAnalyzer, StaticExpressionPropertyCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Complex").WithLocation(0));
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -215,12 +240,13 @@ public class StaticExpressionPropertyCodeFixTests
         }
         """;
 
-        var expected = new[]
-        {
-            Verify.Diagnostic().WithLocation(0).WithArguments("EnvVar"),
-            Verify.Diagnostic().WithLocation(1).WithArguments("Numbers")
-        };
-        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        var test = TestHelper.CreateCodeFixTest<StaticExpressionPropertyAnalyzer, StaticExpressionPropertyCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "EnvVar").WithLocation(0));
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Numbers").WithLocation(1));
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -248,13 +274,14 @@ public class StaticExpressionPropertyCodeFixTests
         }
         """;
 
-        var expected = new[]
-        {
-            Verify.Diagnostic().WithLocation(0).WithArguments("InternalItems"),
-            Verify.Diagnostic().WithLocation(1).WithArguments("ProtectedItems"),
-            Verify.Diagnostic().WithLocation(2).WithArguments("PrivateItems")
-        };
-        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        var test = TestHelper.CreateCodeFixTest<StaticExpressionPropertyAnalyzer, StaticExpressionPropertyCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "InternalItems").WithLocation(0));
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "ProtectedItems").WithLocation(1));
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "PrivateItems").WithLocation(2));
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -278,7 +305,11 @@ public class StaticExpressionPropertyCodeFixTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Items");
-        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        var test = TestHelper.CreateCodeFixTest<StaticExpressionPropertyAnalyzer, StaticExpressionPropertyCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+        test.ExpectedDiagnostics.Add(TestHelper.CreateDiagnostic("TL005", "Items").WithLocation(0));
+        await test.RunAsync(CancellationToken.None);
     }
 }

--- a/test/ToListinator.Tests/StaticExpressionPropertyCodeFixTests.cs
+++ b/test/ToListinator.Tests/StaticExpressionPropertyCodeFixTests.cs
@@ -1,0 +1,284 @@
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
+    ToListinator.Analyzers.StaticExpressionPropertyAnalyzer,
+    ToListinator.CodeFixes.StaticExpressionPropertyCodeFixProvider,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace ToListinator.Tests;
+
+public class StaticExpressionPropertyCodeFixTests
+{
+    [Fact]
+    public async Task ShouldFixEnvironmentMethodCall()
+    {
+        const string testCode = """
+        using System;
+
+        public class TestClass
+        {
+            public static string? {|#0:RoleInstance|} => Environment.GetEnvironmentVariable("MONITORING_ROLE_INSTANCE");
+        }
+        """;
+
+        const string fixedCode = """
+        using System;
+
+        public class TestClass
+        {
+            public static string? RoleInstance { get; } = Environment.GetEnvironmentVariable("MONITORING_ROLE_INSTANCE");
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("RoleInstance");
+        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task ShouldFixNewHashSetCreation()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            public static HashSet<string> {|#0:Items|} => new HashSet<string> { "A", "B", "C" };
+        }
+        """;
+
+        const string fixedCode = """
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            public static HashSet<string> Items { get; } = new HashSet<string> { "A", "B", "C" };
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Items");
+        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task ShouldFixNewListCreation()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            public static List<int> {|#0:Numbers|} => new List<int> { 1, 2, 3 };
+        }
+        """;
+
+        const string fixedCode = """
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            public static List<int> Numbers { get; } = new List<int> { 1, 2, 3 };
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Numbers");
+        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task ShouldFixStringSplit()
+    {
+        const string testCode = """
+        public class TestClass
+        {
+            public static string[] {|#0:Parts|} => "a,b,c".Split(',');
+        }
+        """;
+
+        const string fixedCode = """
+        public class TestClass
+        {
+            public static string[] Parts { get; } = "a,b,c".Split(',');
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Parts");
+        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task ShouldFixPropertyWithXmlDocumentation()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            /// <summary>
+            /// Gets the list of items.
+            /// </summary>
+            public static List<string> {|#0:Items|} => new List<string> { "A", "B" };
+        }
+        """;
+
+        const string fixedCode = """
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            /// <summary>
+            /// Gets the list of items.
+            /// </summary>
+            public static List<string> Items { get; } = new List<string> { "A", "B" };
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Items");
+        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task ShouldFixPropertyWithAttributes()
+    {
+        const string testCode = """
+        using System;
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            [Obsolete("Use NewItems instead")]
+            public static List<string> {|#0:Items|} => new List<string> { "A", "B" };
+        }
+        """;
+
+        const string fixedCode = """
+        using System;
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            [Obsolete("Use NewItems instead")]
+            public static List<string> Items { get; } = new List<string> { "A", "B" };
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Items");
+        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task ShouldFixComplexExpression()
+    {
+        const string testCode = """
+        using System;
+
+        public class TestClass
+        {
+            public static string {|#0:Complex|} => Environment.GetEnvironmentVariable("PATH") ?? "default";
+        }
+        """;
+
+        const string fixedCode = """
+        using System;
+
+        public class TestClass
+        {
+            public static string Complex { get; } = Environment.GetEnvironmentVariable("PATH") ?? "default";
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Complex");
+        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task ShouldFixMultipleProperties()
+    {
+        const string testCode = """
+        using System;
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            public static string? {|#0:EnvVar|} => Environment.GetEnvironmentVariable("KEY");
+            public static List<int> {|#1:Numbers|} => new List<int> { 1, 2, 3 };
+        }
+        """;
+
+        const string fixedCode = """
+        using System;
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            public static string? EnvVar { get; } = Environment.GetEnvironmentVariable("KEY");
+            public static List<int> Numbers { get; } = new List<int> { 1, 2, 3 };
+        }
+        """;
+
+        var expected = new[]
+        {
+            Verify.Diagnostic().WithLocation(0).WithArguments("EnvVar"),
+            Verify.Diagnostic().WithLocation(1).WithArguments("Numbers")
+        };
+        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task ShouldFixPropertyWithDifferentAccessModifiers()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            internal static List<string> {|#0:InternalItems|} => new List<string> { "A" };
+            protected static List<string> {|#1:ProtectedItems|} => new List<string> { "B" };
+            private static List<string> {|#2:PrivateItems|} => new List<string> { "C" };
+        }
+        """;
+
+        const string fixedCode = """
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            internal static List<string> InternalItems { get; } = new List<string> { "A" };
+            protected static List<string> ProtectedItems { get; } = new List<string> { "B" };
+            private static List<string> PrivateItems { get; } = new List<string> { "C" };
+        }
+        """;
+
+        var expected = new[]
+        {
+            Verify.Diagnostic().WithLocation(0).WithArguments("InternalItems"),
+            Verify.Diagnostic().WithLocation(1).WithArguments("ProtectedItems"),
+            Verify.Diagnostic().WithLocation(2).WithArguments("PrivateItems")
+        };
+        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task ShouldFixPropertyWithTrailingComments()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            public static List<string> {|#0:Items|} => new List<string> { "A" }; // This creates a new list
+        }
+        """;
+
+        const string fixedCode = """
+        using System.Collections.Generic;
+
+        public class TestClass
+        {
+            public static List<string> Items { get; } = new List<string> { "A" }; // This creates a new list
+        }
+        """;
+
+        var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Items");
+        await Verify.VerifyCodeFixAsync(testCode, expected, fixedCode);
+    }
+}

--- a/test/ToListinator.Tests/ToListCountAnalyzerTests.cs
+++ b/test/ToListinator.Tests/ToListCountAnalyzerTests.cs
@@ -1,8 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
-    ToListinator.Analyzers.ToListCountAnalyzer,
-    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+using ToListinator.Analyzers;
 
 namespace ToListinator.Tests;
 
@@ -25,8 +22,11 @@ public class ToListCountAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -46,8 +46,11 @@ public class ToListCountAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -67,8 +70,11 @@ public class ToListCountAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -88,8 +94,11 @@ public class ToListCountAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -109,8 +118,11 @@ public class ToListCountAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -130,8 +142,11 @@ public class ToListCountAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -152,7 +167,8 @@ public class ToListCountAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -172,7 +188,8 @@ public class ToListCountAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -193,7 +210,8 @@ public class ToListCountAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -213,8 +231,11 @@ public class ToListCountAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -234,8 +255,11 @@ public class ToListCountAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -255,8 +279,11 @@ public class ToListCountAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -276,8 +303,11 @@ public class ToListCountAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -297,7 +327,10 @@ public class ToListCountAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 }

--- a/test/ToListinator.Tests/ToListCountCodeFixTests.cs
+++ b/test/ToListinator.Tests/ToListCountCodeFixTests.cs
@@ -40,7 +40,7 @@ public class ToListCountCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -81,7 +81,7 @@ public class ToListCountCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -122,7 +122,7 @@ public class ToListCountCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -163,7 +163,7 @@ public class ToListCountCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -204,7 +204,7 @@ public class ToListCountCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -245,7 +245,7 @@ public class ToListCountCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -286,7 +286,7 @@ public class ToListCountCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -327,7 +327,7 @@ public class ToListCountCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -368,7 +368,7 @@ public class ToListCountCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -409,7 +409,7 @@ public class ToListCountCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -450,7 +450,7 @@ public class ToListCountCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
             testCode,
             fixedCode
         );

--- a/test/ToListinator.Tests/ToListForEachAnalyzerTests.cs
+++ b/test/ToListinator.Tests/ToListForEachAnalyzerTests.cs
@@ -1,8 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
-    ToListinator.Analyzers.ToListForEachAnalyzer,
-    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+using ToListinator.Analyzers;
 
 namespace ToListinator.Tests;
 
@@ -26,8 +23,11 @@ public class ToListForEachAnalyzerTests
         }
         """;
 
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+        var test = TestHelper.CreateAnalyzerTest<ToListForEachAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL001").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -51,7 +51,8 @@ public class ToListForEachAnalyzerTests
         }
         """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<ToListForEachAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -73,7 +74,8 @@ public class ToListForEachAnalyzerTests
             }
             """;
 
-        await Verify.VerifyAnalyzerAsync(testCode);
+        var test = TestHelper.CreateAnalyzerTest<ToListForEachAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -93,7 +95,11 @@ public class ToListForEachAnalyzerTests
                 }
             }
             """;
-        var expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(testCode, expected);
+
+        var test = TestHelper.CreateAnalyzerTest<ToListForEachAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL001").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
     }
 }

--- a/test/ToListinator.Tests/ToListForEachCodeFixTests.cs
+++ b/test/ToListinator.Tests/ToListForEachCodeFixTests.cs
@@ -44,7 +44,7 @@ public class ToListForEachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -90,7 +90,7 @@ public class ToListForEachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -136,7 +136,7 @@ public class ToListForEachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -186,7 +186,7 @@ public class ToListForEachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -236,7 +236,7 @@ public class ToListForEachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -296,7 +296,7 @@ public class ToListForEachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -357,7 +357,7 @@ public class ToListForEachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -407,7 +407,7 @@ public class ToListForEachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -461,7 +461,7 @@ public class ToListForEachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
             testCode,
             fixedCode
         );
@@ -515,7 +515,7 @@ public class ToListForEachCodeFixTests
         }
         """;
 
-        var test = CodeFixTestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
+        var test = TestHelper.CreateCodeFixTest<ToListForEachAnalyzer, ToListForEachCodeFixProvider>(
             testCode,
             fixedCode
         );


### PR DESCRIPTION
## Summary

This PR implements TL005, a new Roslyn analyzer that detects static properties using expression body syntax (=>) that may allocate on every access, suggesting conversion to getter-only properties with initializers for better performance.

## Changes

- **New Analyzer**: StaticExpressionPropertyAnalyzer (TL005)
  - Detects static properties with expression bodies that contain allocating operations
  - Targets patterns like Environment.GetEnvironmentVariable(), new expressions, LINQ operations, string methods
  
- **New Code Fix**: StaticExpressionPropertyCodeFixProvider
  - Transforms static Type Property => expression; to static Type Property { get; } = expression;
  - Preserves XML documentation, attributes, and formatting
  
- **Comprehensive Test Suite**: 29 new tests (16 analyzer tests + 13 code fix tests)
  - Covers positive cases (should trigger) and negative cases (should not trigger)
  - Tests complex scenarios including conditionals, multiple violations, and edge cases

## Test Results
- **Total Tests**: 105 (68 existing + 29 new + 8 utils tests)
- **Status**: All tests passing
- **Build**: Clean build successful

## Documentation Updated
- Added TL005 to AnalyzerReleases.Unshipped.md
- Created comprehensive implementation plan documentation

Fixes #15