### PR TITLE
Extend TL003 to detect ToArray().Length patterns

### DIFF
--- a/test/ToListinator.TestApp/Program.cs
+++ b/test/ToListinator.TestApp/Program.cs
@@ -24,6 +24,11 @@ class Program
         // This should trigger an analyzer warning.
         var any = numbers.ToList().Count > 0;
 
+        // NEW: These should trigger TL003 for ToArray().Length patterns
+        var arrayEmpty = numbers.ToArray().Length == 0;
+        var arrayNotEmpty = numbers.ToArray().Length > 0;
+        var arrayHasItems = numbers.Where(x => x > 2).ToArray().Length != 0;
+
         // This should trigger an analyzer warning
         numbers.ToList().ForEach(x => Console.WriteLine($"Number: {x}"));
 

--- a/test/ToListinator.Tests/ToListCountAnalyzerTests.cs
+++ b/test/ToListinator.Tests/ToListCountAnalyzerTests.cs
@@ -333,4 +333,191 @@ public class ToListCountAnalyzerTests
         );
         await test.RunAsync(CancellationToken.None);
     }
+
+    // ToArray().Length tests
+    [Fact]
+    public async Task ShouldReportWarningForToArrayLengthGreaterThanZero()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        public class TestClass
+        {
+            public void TestMethod()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var hasAny = {|#0:numbers.ToArray().Length > 0|};
+            }
+        }
+        """;
+
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForToArrayLengthGreaterThanOrEqualOne()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        public class TestClass
+        {
+            public void TestMethod()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var hasAny = {|#0:numbers.ToArray().Length >= 1|};
+            }
+        }
+        """;
+
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForToArrayLengthNotEqualsZero()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        public class TestClass
+        {
+            public void TestMethod()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var hasAny = {|#0:numbers.ToArray().Length != 0|};
+            }
+        }
+        """;
+
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForToArrayLengthEqualsZero()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        public class TestClass
+        {
+            public void TestMethod()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var isEmpty = {|#0:numbers.ToArray().Length == 0|};
+            }
+        }
+        """;
+
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForReversedToArrayLengthComparison()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        public class TestClass
+        {
+            public void TestMethod()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var hasAny = {|#0:0 < numbers.ToArray().Length|};
+            }
+        }
+        """;
+
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ShouldReportWarningForToArrayLengthWithWhereChain()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        public class TestClass
+        {
+            public void TestMethod()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var hasValidItems = {|#0:numbers.Where(x => x > 1).ToArray().Length > 0|};
+            }
+        }
+        """;
+
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(
+            testCode,
+            TestHelper.CreateDiagnostic("TL003").WithLocation(0)
+        );
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ShouldNotReportWarningForRegularArrayLength()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        public class TestClass
+        {
+            public void TestMethod()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var length = numbers.Length > 0; // This should not trigger - it's a regular array
+            }
+        }
+        """;
+
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ShouldNotReportWarningForRegularListCount()
+    {
+        const string testCode = """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        public class TestClass
+        {
+            public void TestMethod()
+            {
+                var numbers = new List<int> { 1, 2, 3 };
+                var hasAny = numbers.Count > 0; // This should not trigger - it's a regular List.Count
+            }
+        }
+        """;
+
+        var test = TestHelper.CreateAnalyzerTest<ToListCountAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
+    }
 }

--- a/test/ToListinator.Tests/ToListCountCodeFixTests.cs
+++ b/test/ToListinator.Tests/ToListCountCodeFixTests.cs
@@ -457,4 +457,253 @@ public class ToListCountCodeFixTests
 
         await test.RunAsync(CancellationToken.None);
     }
+
+    // ToArray().Length code fix tests
+    [Fact]
+    public async Task ReplaceToArrayLengthGreaterThanZeroWithAny()
+    {
+        var testCode =
+        """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        class C
+        {
+            void M()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var hasAny = {|TL003:numbers.ToArray().Length > 0|};
+            }
+        }
+        """;
+
+        var fixedCode =
+        """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        class C
+        {
+            void M()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var hasAny = numbers.Any();
+            }
+        }
+        """;
+
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ReplaceToArrayLengthEqualsZeroWithNotAny()
+    {
+        var testCode =
+        """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        class C
+        {
+            void M()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var isEmpty = {|TL003:numbers.ToArray().Length == 0|};
+            }
+        }
+        """;
+
+        var fixedCode =
+        """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        class C
+        {
+            void M()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var isEmpty = !numbers.Any();
+            }
+        }
+        """;
+
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ReplaceToArrayLengthNotEqualsZeroWithAny()
+    {
+        var testCode =
+        """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        class C
+        {
+            void M()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var hasAny = {|TL003:numbers.ToArray().Length != 0|};
+            }
+        }
+        """;
+
+        var fixedCode =
+        """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        class C
+        {
+            void M()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var hasAny = numbers.Any();
+            }
+        }
+        """;
+
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ReplaceToArrayLengthWithWhereChain()
+    {
+        var testCode =
+        """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        class C
+        {
+            void M()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var hasValidItems = {|TL003:numbers.Where(x => x > 1).ToArray().Length > 0|};
+            }
+        }
+        """;
+
+        var fixedCode =
+        """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        class C
+        {
+            void M()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var hasValidItems = numbers.Where(x => x > 1).Any();
+            }
+        }
+        """;
+
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ReplaceReversedToArrayLengthComparison()
+    {
+        var testCode =
+        """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        class C
+        {
+            void M()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var hasAny = {|TL003:0 < numbers.ToArray().Length|};
+            }
+        }
+        """;
+
+        var fixedCode =
+        """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        class C
+        {
+            void M()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                var hasAny = numbers.Any();
+            }
+        }
+        """;
+
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task PreservesCommentsWithToArrayLength()
+    {
+        var testCode =
+        """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        class C
+        {
+            void M()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                // Check if we have any items
+                var hasAny = {|TL003:numbers.ToArray().Length > 0|}; // This is a comment
+            }
+        }
+        """;
+
+        var fixedCode =
+        """
+        using System.Collections.Generic;
+        using System.Linq;
+
+        class C
+        {
+            void M()
+            {
+                var numbers = new[] { 1, 2, 3 };
+                // Check if we have any items
+                var hasAny = numbers.Any(); // This is a comment
+            }
+        }
+        """;
+
+        var test = TestHelper.CreateCodeFixTest<ToListCountAnalyzer, ToListCountCodeFixProvider>(
+            testCode,
+            fixedCode
+        );
+
+        await test.RunAsync(CancellationToken.None);
+    }
 }


### PR DESCRIPTION
## Overview

This PR extends the existing TL003 analyzer to detect `ToArray().Length` patterns in addition to the existing `ToList().Count` patterns, addressing issue #28.

## Changes Made

### Core Analyzer Changes
- **Enhanced `ToListCountAnalyzer`** to detect both `ToList().Count` and `ToArray().Length` patterns
- **Updated diagnostic messages** to reflect both patterns: "Avoid using {methodType} for existence checks"
- **Extended pattern matching** with new `IsToListCountOrToArrayLengthExpression` method
- **Maintained backward compatibility** - all existing functionality preserved

### Code Fix Provider Updates
- **Extended `ToListCountCodeFixProvider`** to handle both Count and Length patterns
- **Updated extraction logic** to work with both `ToList().Count` and `ToArray().Length` expressions
- **Same fix applies to both patterns** - replace with `Any()` or `!Any()` calls

### Comprehensive Test Coverage
- **Added 8 new analyzer tests** for ToArray().Length patterns
- **Added 6 new code fix tests** for ToArray().Length scenarios
- **Included edge cases**: Where chains, reversed comparisons, comment preservation
- **Verified negative test cases**: Regular array.Length and List.Count should not trigger

### Real-World Testing
- **Added test patterns** to `ToListinator.TestApp` for verification
- **Confirmed analyzer warnings** appear correctly for new patterns
- **All 255 existing tests pass** - no regressions introduced

## Patterns Now Detected

### ToList().Count Patterns (existing)
```csharp
// ❌ Detected by TL003
if (items.ToList().Count > 0) { }
if (items.ToList().Count == 0) { }

// ✅ Fixed to
if (items.Any()) { }
if (!items.Any()) { }
```

### ToArray().Length Patterns (new)
```csharp
// ❌ Now detected by TL003  
if (items.ToArray().Length > 0) { }
if (items.ToArray().Length == 0) { }
if (items.Where(x => x.IsValid).ToArray().Length != 0) { }

// ✅ Fixed to
if (items.Any()) { }
if (!items.Any()) { }
if (items.Where(x => x.IsValid).Any()) { }
```

## Why This Approach?

**✅ Extending TL003 vs. Creating New Analyzer:**
- Same fundamental performance problem (materializing collections for existence checks)
- Leverages existing infrastructure (binary expression analysis, negation logic)
- Provides cohesive user experience - one rule for both patterns
- Avoids diagnostic ID collision (issue #28 requested TL007, but it's already used)

## Test Results

- **All 255 tests passing** ✅
- **New ToArray().Length patterns detected** in test application ✅  
- **Code fixes working correctly** for both Count and Length ✅
- **Existing functionality preserved** ✅

## Closes

Closes #28 

## Example Output

From the test application build:
```
warning TL003: Avoid using ToArray().Length for existence checks. Use Any() to avoid unnecessary allocation.
warning TL003: Avoid using ToArray().Length for existence checks. Use Any() to avoid unnecessary allocation.  
warning TL003: Avoid using ToArray().Length for existence checks. Use Any() to avoid unnecessary allocation.
```

The analyzer now catches both the original `ToList().Count` anti-patterns and the requested `ToArray().Length` patterns under a single, cohesive rule.