### PR TITLE
Add repository URL to DateTimeDetector package metadata

### DIFF
--- a/src/DateTimeDetector/DateTimeDetector.csproj
+++ b/src/DateTimeDetector/DateTimeDetector.csproj
@@ -12,6 +12,9 @@
     <Title>DateTimeDetector Analyzer and CodeFixes</Title>
     <Authors>Treit</Authors>
     <Description>A Roslyn analyzer that detects usage of DateTime and suggests using DateTimeOffset instead.</Description>
+    <PackageProjectUrl>https://github.com/Treit/ToListinator</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Treit/ToListinator</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
     <PackageTags>analyzer;roslyn;csharp;datetime;datetimeoffset;codefix</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
## Summary
Adds `PackageProjectUrl`, `RepositoryUrl`, and `RepositoryType` to the DateTimeDetector NuGet package metadata so that nuget.org displays a link to the source repository.

This was missing from the initial DateTimeDetector PR (#73).

## Changes
- `src/DateTimeDetector/DateTimeDetector.csproj`: Added repository metadata properties
