### PR TITLE
Fix DT001 for fully qualified DateTime member access

### DIFF
--- a/src/DateTimeDetector.Analyzers/DateTimeUsageAnalyzer.cs
+++ b/src/DateTimeDetector.Analyzers/DateTimeUsageAnalyzer.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 
 namespace DateTimeDetector.Analyzers;
 
@@ -51,15 +52,7 @@ public class DateTimeUsageAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Skip if this identifier is inside a DateTimeOffset usage (e.g., DateTimeOffset.DateTime property)
-        if (identifierName.Parent is MemberAccessExpressionSyntax memberAccess
-            && memberAccess.Name == identifierName)
-        {
-            return;
-        }
-
-        var symbolInfo = context.SemanticModel.GetSymbolInfo(identifierName, context.CancellationToken);
-        var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+        var symbol = GetSymbol(context.SemanticModel, identifierName, context.CancellationToken);
 
         var typeSymbol = symbol switch
         {
@@ -76,5 +69,22 @@ public class DateTimeUsageAnalyzer : DiagnosticAnalyzer
         {
             context.ReportDiagnostic(Diagnostic.Create(Rule, identifierName.GetLocation()));
         }
+    }
+
+    private static ISymbol? GetSymbol(
+        SemanticModel semanticModel,
+        IdentifierNameSyntax identifierName,
+        CancellationToken cancellationToken)
+    {
+        SyntaxNode semanticTarget = identifierName.Parent switch
+        {
+            MemberAccessExpressionSyntax memberAccess when memberAccess.Name == identifierName => memberAccess,
+            QualifiedNameSyntax qualifiedName when qualifiedName.Right == identifierName => qualifiedName,
+            AliasQualifiedNameSyntax aliasQualifiedName when aliasQualifiedName.Name == identifierName => aliasQualifiedName,
+            _ => identifierName
+        };
+
+        var symbolInfo = semanticModel.GetSymbolInfo(semanticTarget, cancellationToken);
+        return symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
     }
 }

--- a/test/DateTimeDetector.Tests/DateTimeUsageAnalyzerTests.cs
+++ b/test/DateTimeDetector.Tests/DateTimeUsageAnalyzerTests.cs
@@ -1,4 +1,5 @@
 using DateTimeDetector.Analyzers;
+using Microsoft.CodeAnalysis;
 
 namespace DateTimeDetector.Tests;
 
@@ -112,6 +113,42 @@ public class DateTimeUsageAnalyzerTests
     }
 
     [Fact]
+    public async Task DetectsFullyQualifiedDateTimeStaticMembers()
+    {
+        var testCode = """
+            class C
+            {
+                void M()
+                {
+                    var now = System.{|DT001:DateTime|}.Now;
+                    var utcNow = System.{|DT001:DateTime|}.UtcNow;
+                }
+            }
+            """;
+
+        var test = TestHelper.CreateAnalyzerTest<DateTimeUsageAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task DetectsTopLevelFullyQualifiedDateTimeStaticMembers()
+    {
+        var testCode = """
+            using System;
+
+            var localNow = System.{|DT001:DateTime|}.Now;
+            var utcNow = System.{|DT001:DateTime|}.UtcNow;
+
+            Console.WriteLine(localNow);
+            Console.WriteLine(utcNow);
+            """;
+
+        var test = TestHelper.CreateAnalyzerTest<DateTimeUsageAnalyzer>(testCode);
+        test.TestState.OutputKind = OutputKind.ConsoleApplication;
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
     public async Task DetectsNewDateTime()
     {
         var testCode = """
@@ -141,6 +178,25 @@ public class DateTimeUsageAnalyzerTests
                 void M()
                 {
                     DateTimeOffset now = DateTimeOffset.Now;
+                }
+            }
+            """;
+
+        var test = TestHelper.CreateAnalyzerTest<DateTimeUsageAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task DoesNotFlagDateTimeOffsetDateTimeProperty()
+    {
+        var testCode = """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                    var dt = DateTimeOffset.Now.DateTime;
                 }
             }
             """;

--- a/test/DateTimeDetector.Tests/DateTimeUsageCodeFixTests.cs
+++ b/test/DateTimeDetector.Tests/DateTimeUsageCodeFixTests.cs
@@ -1,5 +1,6 @@
 using DateTimeDetector.Analyzers;
 using DateTimeDetector.CodeFixes;
+using Microsoft.CodeAnalysis;
 
 namespace DateTimeDetector.Tests;
 
@@ -122,6 +123,36 @@ public class DateTimeUsageCodeFixTests
 
         var test = TestHelper.CreateCodeFixTest<DateTimeUsageAnalyzer, DateTimeUsageCodeFixProvider>(
             testCode, fixedCode);
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task FixesTopLevelFullyQualifiedDateTimeStaticMembers()
+    {
+        var testCode = """
+            using System;
+
+            var localNow = System.{|DT001:DateTime|}.Now;
+            var utcNow = System.{|DT001:DateTime|}.UtcNow;
+
+            Console.WriteLine(localNow);
+            Console.WriteLine(utcNow);
+            """;
+
+        var fixedCode = """
+            using System;
+
+            var localNow = System.DateTimeOffset.Now;
+            var utcNow = System.DateTimeOffset.UtcNow;
+
+            Console.WriteLine(localNow);
+            Console.WriteLine(utcNow);
+            """;
+
+        var test = TestHelper.CreateCodeFixTest<DateTimeUsageAnalyzer, DateTimeUsageCodeFixProvider>(
+            testCode, fixedCode);
+        test.TestState.OutputKind = OutputKind.ConsoleApplication;
+        test.FixedState.OutputKind = OutputKind.ConsoleApplication;
         await test.RunAsync(CancellationToken.None);
     }
 


### PR DESCRIPTION
## Summary
- fix DT001 so fully qualified static member access like `System.DateTime.Now` and `System.DateTime.UtcNow` is reported
- preserve valid `DateTimeOffset.DateTime` member access by resolving the full member access symbol when needed
- add regression tests for method-local and top-level fully qualified usage, plus a non-regression test for `DateTimeOffset.Now.DateTime`

## Testing
- `dotnet test test\DateTimeDetector.Tests\DateTimeDetector.Tests.csproj -nologo`
- `dotnet test -nologo`

Fixes #75