### PR TITLE
Fix DT001 unsafe DateTime to DateTimeOffset rewrites

### DIFF
--- a/src/DateTimeDetector.Analyzers/DateTimeUsageAnalyzer.cs
+++ b/src/DateTimeDetector.Analyzers/DateTimeUsageAnalyzer.cs
@@ -36,13 +36,22 @@ public class DateTimeUsageAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
+            var dateTimeOffsetType = startContext.Compilation.GetTypeByMetadataName("System.DateTimeOffset");
+            if (dateTimeOffsetType is null)
+            {
+                return;
+            }
+
             startContext.RegisterSyntaxNodeAction(
-                nodeContext => AnalyzeIdentifier(nodeContext, dateTimeType),
+                nodeContext => AnalyzeIdentifier(nodeContext, dateTimeType, dateTimeOffsetType),
                 SyntaxKind.IdentifierName);
         });
     }
 
-    private static void AnalyzeIdentifier(SyntaxNodeAnalysisContext context, INamedTypeSymbol dateTimeType)
+    private static void AnalyzeIdentifier(
+        SyntaxNodeAnalysisContext context,
+        INamedTypeSymbol dateTimeType,
+        INamedTypeSymbol dateTimeOffsetType)
     {
         var identifierName = (IdentifierNameSyntax)context.Node;
 
@@ -97,7 +106,48 @@ public class DateTimeUsageAnalyzer : DiagnosticAnalyzer
         if (typeSymbol is not null
             && SymbolEqualityComparer.Default.Equals(typeSymbol, dateTimeType))
         {
+            // Don't flag static member access (DateTime.Foo) when DateTimeOffset has no equivalent member
+            if (IsUnfixableStaticMemberAccess(identifierName, dateTimeOffsetType))
+            {
+                return;
+            }
+
             context.ReportDiagnostic(Diagnostic.Create(Rule, nodeToReport.GetLocation()));
         }
+    }
+
+    private static bool IsUnfixableStaticMemberAccess(
+        IdentifierNameSyntax dateTimeIdentifier,
+        INamedTypeSymbol dateTimeOffsetType)
+    {
+        // DateTime is the left side of DateTime.Something (expression position)
+        if (dateTimeIdentifier.Parent is MemberAccessExpressionSyntax memberAccess
+            && memberAccess.Expression == dateTimeIdentifier)
+        {
+            var memberName = memberAccess.Name.Identifier.ValueText;
+            return !dateTimeOffsetType.GetMembers(memberName).Any();
+        }
+
+        // System.DateTime is the left side of System.DateTime.Something (fully-qualified expression position)
+        if (dateTimeIdentifier.Parent is MemberAccessExpressionSyntax qualifiedDateTimeAccess
+            && qualifiedDateTimeAccess.Name == dateTimeIdentifier
+            && qualifiedDateTimeAccess.Parent is MemberAccessExpressionSyntax outerAccess
+            && outerAccess.Expression == qualifiedDateTimeAccess)
+        {
+            var memberName = outerAccess.Name.Identifier.ValueText;
+            return !dateTimeOffsetType.GetMembers(memberName).Any();
+        }
+
+        // System.DateTime in type position (QualifiedNameSyntax) used as expression for member access
+        if (dateTimeIdentifier.Parent is QualifiedNameSyntax qualifiedName
+            && qualifiedName.Right == dateTimeIdentifier
+            && qualifiedName.Parent is MemberAccessExpressionSyntax qualifiedMemberAccess
+            && qualifiedMemberAccess.Expression == qualifiedName)
+        {
+            var memberName = qualifiedMemberAccess.Name.Identifier.ValueText;
+            return !dateTimeOffsetType.GetMembers(memberName).Any();
+        }
+
+        return false;
     }
 }

--- a/src/DateTimeDetector.CodeFixes/DateTimeUsageCodeFixProvider.cs
+++ b/src/DateTimeDetector.CodeFixes/DateTimeUsageCodeFixProvider.cs
@@ -44,12 +44,162 @@ public class DateTimeUsageCodeFixProvider : CodeFixProvider
             return;
         }
 
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+        {
+            return;
+        }
+
+        var dateTimeOffsetType = semanticModel.Compilation.GetTypeByMetadataName("System.DateTimeOffset");
+        if (dateTimeOffsetType is null)
+        {
+            return;
+        }
+
+        // Check if the rewrite would be safe
+        if (!IsRewriteSafe(identifierNode, dateTimeOffsetType, semanticModel, context.CancellationToken))
+        {
+            return;
+        }
+
         context.RegisterCodeFix(
             CodeAction.Create(
                 title: "Replace DateTime with DateTimeOffset",
                 createChangedDocument: ct => ReplaceWithDateTimeOffset(context.Document, identifierNode, ct),
                 equivalenceKey: "ReplaceDateTimeWithDateTimeOffset"),
             diagnostic);
+    }
+
+    private static bool IsRewriteSafe(
+        IdentifierNameSyntax identifierNode,
+        INamedTypeSymbol dateTimeOffsetType,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        // Check for instance member chains that would break
+        // e.g., DateTime.Now.Kind → DateTimeOffset.Now.Kind (Kind doesn't exist on DateTimeOffset)
+        if (IsUnsafeChain(identifierNode, dateTimeOffsetType, semanticModel, cancellationToken))
+        {
+            return false;
+        }
+
+        // Check for constructor overloads that don't exist on DateTimeOffset
+        // e.g., new DateTime(2024, 1, 2) → new DateTimeOffset(2024, 1, 2) (no matching ctor)
+        if (IsUnsafeConstructor(identifierNode, dateTimeOffsetType, semanticModel, cancellationToken))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsUnsafeChain(
+        IdentifierNameSyntax dateTimeIdentifier,
+        INamedTypeSymbol dateTimeOffsetType,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        // Find the member access where DateTime is used as the type (e.g., DateTime.Now)
+        // Then check if that member access is itself part of a longer chain
+        MemberAccessExpressionSyntax? staticAccess = null;
+
+        if (dateTimeIdentifier.Parent is MemberAccessExpressionSyntax directAccess
+            && directAccess.Expression == dateTimeIdentifier)
+        {
+            // DateTime.Now — dateTimeIdentifier is the expression
+            staticAccess = directAccess;
+        }
+        else if (dateTimeIdentifier.Parent is MemberAccessExpressionSyntax qualifiedAccess
+            && qualifiedAccess.Name == dateTimeIdentifier
+            && qualifiedAccess.Parent is MemberAccessExpressionSyntax outerAccess
+            && outerAccess.Expression == qualifiedAccess)
+        {
+            // System.DateTime.Now — qualifiedAccess is System.DateTime, outerAccess is ...Now
+            staticAccess = outerAccess;
+        }
+
+        if (staticAccess is null)
+        {
+            return false;
+        }
+
+        // Now check: does the static access resolve to a member that returns DateTime,
+        // and is it followed by another member access?
+        // e.g., DateTime.Now.Kind — staticAccess is DateTime.Now, we need to check .Kind
+        SyntaxNode current = staticAccess.Parent is InvocationExpressionSyntax invocation
+            ? invocation  // DateTime.Parse(...) — the invocation is the full expression
+            : staticAccess; // DateTime.Now — the member access itself is the expression
+
+        // Walk up: is this expression used as the left side of another member access?
+        if (current.Parent is MemberAccessExpressionSyntax chainedAccess
+            && chainedAccess.Expression == current)
+        {
+            var chainedMemberName = chainedAccess.Name.Identifier.ValueText;
+            if (!dateTimeOffsetType.GetMembers(chainedMemberName).Any())
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsUnsafeConstructor(
+        IdentifierNameSyntax dateTimeIdentifier,
+        INamedTypeSymbol dateTimeOffsetType,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        // Check if this DateTime is inside a "new DateTime(...)" expression
+        if (dateTimeIdentifier.Parent is not ObjectCreationExpressionSyntax objectCreation
+            || objectCreation.Type != dateTimeIdentifier)
+        {
+            return false;
+        }
+
+        // Get argument types
+        var argList = objectCreation.ArgumentList;
+        if (argList is null || argList.Arguments.Count == 0)
+        {
+            // new DateTime() — parameterless ctor exists on DateTimeOffset
+            return false;
+        }
+
+        var argTypes = argList.Arguments
+            .Select(a => semanticModel.GetTypeInfo(a.Expression, cancellationToken).Type)
+            .ToList();
+
+        if (argTypes.Any(t => t is null))
+        {
+            return true; // Can't determine types — be conservative
+        }
+
+        // Check if DateTimeOffset has a constructor with compatible parameter types
+        var compilation = semanticModel.Compilation;
+        foreach (var ctor in dateTimeOffsetType.InstanceConstructors)
+        {
+            if (ctor.Parameters.Length != argTypes.Count)
+            {
+                continue;
+            }
+
+            var allMatch = true;
+            for (int i = 0; i < ctor.Parameters.Length; i++)
+            {
+                if (!compilation.HasImplicitConversion(argTypes[i]!, ctor.Parameters[i].Type))
+                {
+                    allMatch = false;
+                    break;
+                }
+            }
+
+            if (allMatch)
+            {
+                return false; // Found a matching ctor — safe to rewrite
+            }
+        }
+
+        return true; // No matching ctor — unsafe
     }
 
     private static async Task<Document> ReplaceWithDateTimeOffset(

--- a/test/DateTimeDetector.Tests/DateTimeUsageAnalyzerTests.cs
+++ b/test/DateTimeDetector.Tests/DateTimeUsageAnalyzerTests.cs
@@ -262,4 +262,118 @@ public class DateTimeUsageAnalyzerTests
         var test = TestHelper.CreateAnalyzerTest<DateTimeUsageAnalyzer>(testCode);
         await test.RunAsync(CancellationToken.None);
     }
+
+    [Fact]
+    public async Task DoesNotFlagDateTimeToday()
+    {
+        var testCode = """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                    var today = DateTime.Today;
+                }
+            }
+            """;
+
+        var test = TestHelper.CreateAnalyzerTest<DateTimeUsageAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task DoesNotFlagDateTimeDaysInMonth()
+    {
+        var testCode = """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                    var days = DateTime.DaysInMonth(2024, 2);
+                }
+            }
+            """;
+
+        var test = TestHelper.CreateAnalyzerTest<DateTimeUsageAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task DoesNotFlagDateTimeIsLeapYear()
+    {
+        var testCode = """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                    var leap = DateTime.IsLeapYear(2024);
+                }
+            }
+            """;
+
+        var test = TestHelper.CreateAnalyzerTest<DateTimeUsageAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task DoesNotFlagDateTimeSpecifyKind()
+    {
+        var testCode = """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                    var value = DateTime.SpecifyKind({|DT001:DateTime|}.Now, DateTimeKind.Utc);
+                }
+            }
+            """;
+
+        var test = TestHelper.CreateAnalyzerTest<DateTimeUsageAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task DoesNotFlagDateTimeFromBinary()
+    {
+        var testCode = """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                    var value = DateTime.FromBinary(42L);
+                }
+            }
+            """;
+
+        var test = TestHelper.CreateAnalyzerTest<DateTimeUsageAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task DoesNotFlagDateTimeFromOADate()
+    {
+        var testCode = """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                    var value = DateTime.FromOADate(45291d);
+                }
+            }
+            """;
+
+        var test = TestHelper.CreateAnalyzerTest<DateTimeUsageAnalyzer>(testCode);
+        await test.RunAsync(CancellationToken.None);
+    }
 }

--- a/test/DateTimeDetector.Tests/DateTimeUsageCodeFixTests.cs
+++ b/test/DateTimeDetector.Tests/DateTimeUsageCodeFixTests.cs
@@ -272,4 +272,109 @@ public class DateTimeUsageCodeFixTests
         test.FixedState.OutputKind = Microsoft.CodeAnalysis.OutputKind.ConsoleApplication;
         await test.RunAsync(CancellationToken.None);
     }
+
+    [Fact]
+    public async Task DoesNotFixDateTimeNowKind()
+    {
+        var testCode = """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                    var kind = {|DT001:DateTime|}.Now.Kind;
+                }
+            }
+            """;
+
+        var test = TestHelper.CreateCodeFixTest<DateTimeUsageAnalyzer, DateTimeUsageCodeFixProvider>(
+            testCode, testCode);
+        test.FixedState.MarkupHandling = Microsoft.CodeAnalysis.Testing.MarkupMode.Allow;
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task DoesNotFixDateTimeNowToBinary()
+    {
+        var testCode = """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                    var binary = {|DT001:DateTime|}.Now.ToBinary();
+                }
+            }
+            """;
+
+        var test = TestHelper.CreateCodeFixTest<DateTimeUsageAnalyzer, DateTimeUsageCodeFixProvider>(
+            testCode, testCode);
+        test.FixedState.MarkupHandling = Microsoft.CodeAnalysis.Testing.MarkupMode.Allow;
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task DoesNotFixDateTimeNowToShortDateString()
+    {
+        var testCode = """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                    var text = {|DT001:DateTime|}.Now.ToShortDateString();
+                }
+            }
+            """;
+
+        var test = TestHelper.CreateCodeFixTest<DateTimeUsageAnalyzer, DateTimeUsageCodeFixProvider>(
+            testCode, testCode);
+        test.FixedState.MarkupHandling = Microsoft.CodeAnalysis.Testing.MarkupMode.Allow;
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task DoesNotFixNewDateTimeThreeArgs()
+    {
+        var testCode = """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                    var value = new {|DT001:DateTime|}(2024, 1, 2);
+                }
+            }
+            """;
+
+        var test = TestHelper.CreateCodeFixTest<DateTimeUsageAnalyzer, DateTimeUsageCodeFixProvider>(
+            testCode, testCode);
+        test.FixedState.MarkupHandling = Microsoft.CodeAnalysis.Testing.MarkupMode.Allow;
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task DoesNotFixNewDateTimeTicks()
+    {
+        var testCode = """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                    var value = new {|DT001:DateTime|}(638460000000000000L);
+                }
+            }
+            """;
+
+        var test = TestHelper.CreateCodeFixTest<DateTimeUsageAnalyzer, DateTimeUsageCodeFixProvider>(
+            testCode, testCode);
+        test.FixedState.MarkupHandling = Microsoft.CodeAnalysis.Testing.MarkupMode.Allow;
+        await test.RunAsync(CancellationToken.None);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #78 — DT001 no longer produces uncompilable code when applying the DateTime → DateTimeOffset code fix.

## Design Philosophy

**Don't flag what you can't fix.** The analyzer and code fix are now context-aware:

- **Don't flag:** Static members with no `DateTimeOffset` equivalent (`Today`, `DaysInMonth`, `IsLeapYear`, `SpecifyKind`, `FromBinary`, `FromOADate`)
- **Flag but don't offer a fix:** Instance member chains that would break (`DateTime.Now.Kind`, `.ToBinary()`, `.ToShortDateString()`), and constructors with no matching `DateTimeOffset` overload (`new DateTime(y,m,d)`, `new DateTime(ticks)`)
- **Flag and fix:** Everything else (type declarations, `Now`, `UtcNow`, `new DateTime()`, generic type arguments)

## Implementation

### Layer 1: Analyzer suppression

When `DateTime` is used in a static member access (`DateTime.Foo`), the analyzer checks if `DateTimeOffset` has a member with the same name via `dateTimeOffsetType.GetMembers(memberName)`. If not → no diagnostic.

### Layer 2: Code fix suppression

For diagnostics that DO fire, the code fix validates the rewrite is safe:

- **Chain detection:** Walks the syntax tree upward from `DateTime.Now` to check if downstream members (`.Kind`, `.ToBinary()`) exist on `DateTimeOffset`
- **Constructor validation:** Checks `DateTimeOffset.InstanceConstructors` for a matching overload using `Compilation.HasImplicitConversion` on each parameter

## Tests Added

- 6 analyzer negative tests (diagnostic should NOT fire)
- 5 code fix tests (diagnostic fires, fix NOT offered)
- All 34 DateTimeDetector tests pass, 367 total tests pass
