### PR TITLE
Deduplicate ToListCount and ToArrayLength analyzer logic

### DIFF
--- a/src/ToListinator.Analyzers/ToArrayLengthAnalyzer.cs
+++ b/src/ToListinator.Analyzers/ToArrayLengthAnalyzer.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 using System.Collections.Immutable;
+using ToListinator.Analyzers.Utils;
 
 namespace ToListinator.Analyzers;
 
@@ -43,67 +44,14 @@ public class ToArrayLengthAnalyzer : DiagnosticAnalyzer
     {
         var binary = (IBinaryOperation)context.Operation;
 
-        if (TryMatchToArrayLengthComparison(binary.LeftOperand, binary.RightOperand, binary.OperatorKind, isLengthOnLeft: true, enumerableType)
-            || TryMatchToArrayLengthComparison(binary.RightOperand, binary.LeftOperand, binary.OperatorKind, isLengthOnLeft: false, enumerableType))
+        if (ConversionComparisonHelper.TryMatchConversionPropertyComparison(
+                binary.LeftOperand, binary.RightOperand, binary.OperatorKind,
+                isPropertyOnLeft: true, "Length", "ToArray", enumerableType)
+            || ConversionComparisonHelper.TryMatchConversionPropertyComparison(
+                binary.RightOperand, binary.LeftOperand, binary.OperatorKind,
+                isPropertyOnLeft: false, "Length", "ToArray", enumerableType))
         {
             context.ReportDiagnostic(Diagnostic.Create(Rule, binary.Syntax.GetLocation()));
         }
-    }
-
-    private static bool TryMatchToArrayLengthComparison(
-        IOperation lengthSide,
-        IOperation constantSide,
-        BinaryOperatorKind operatorKind,
-        bool isLengthOnLeft,
-        INamedTypeSymbol enumerableType)
-    {
-        if (lengthSide is not IPropertyReferenceOperation
-            {
-                Property.Name: "Length",
-                Instance: IInvocationOperation { TargetMethod: { Name: "ToArray" } toArrayMethod }
-            }
-            || !SymbolEqualityComparer.Default.Equals(toArrayMethod.ContainingType, enumerableType))
-        {
-            return false;
-        }
-
-        if (constantSide is not ILiteralOperation { ConstantValue: { HasValue: true, Value: int constantValue } }
-            || constantValue is not (0 or 1))
-        {
-            return false;
-        }
-
-        return IsValidLengthComparisonPattern(operatorKind, constantValue, isLengthOnLeft);
-    }
-
-    private static bool IsValidLengthComparisonPattern(
-        BinaryOperatorKind operatorKind,
-        int constantValue,
-        bool isLengthOnLeft)
-    {
-        if (isLengthOnLeft)
-        {
-            return operatorKind switch
-            {
-                BinaryOperatorKind.GreaterThan when constantValue == 0 => true,
-                BinaryOperatorKind.GreaterThanOrEqual when constantValue == 1 => true,
-                BinaryOperatorKind.NotEquals when constantValue == 0 => true,
-                BinaryOperatorKind.Equals when constantValue == 0 => true,
-                BinaryOperatorKind.LessThanOrEqual when constantValue == 0 => true,
-                BinaryOperatorKind.LessThan when constantValue == 1 => true,
-                _ => false
-            };
-        }
-
-        return operatorKind switch
-        {
-            BinaryOperatorKind.LessThan when constantValue == 0 => true,
-            BinaryOperatorKind.LessThanOrEqual when constantValue == 1 => true,
-            BinaryOperatorKind.NotEquals when constantValue == 0 => true,
-            BinaryOperatorKind.Equals when constantValue == 0 => true,
-            BinaryOperatorKind.GreaterThanOrEqual when constantValue == 0 => true,
-            BinaryOperatorKind.GreaterThan when constantValue == 1 => true,
-            _ => false
-        };
     }
 }

--- a/src/ToListinator.Analyzers/ToListCountAnalyzer.cs
+++ b/src/ToListinator.Analyzers/ToListCountAnalyzer.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 using System.Collections.Immutable;
+using ToListinator.Analyzers.Utils;
 
 namespace ToListinator.Analyzers;
 
@@ -43,71 +44,14 @@ public class ToListCountAnalyzer : DiagnosticAnalyzer
     {
         var binary = (IBinaryOperation)context.Operation;
 
-        if (TryMatchToListCountComparison(binary.LeftOperand, binary.RightOperand, binary.OperatorKind, isCountOnLeft: true, enumerableType)
-            || TryMatchToListCountComparison(binary.RightOperand, binary.LeftOperand, binary.OperatorKind, isCountOnLeft: false, enumerableType))
+        if (ConversionComparisonHelper.TryMatchConversionPropertyComparison(
+                binary.LeftOperand, binary.RightOperand, binary.OperatorKind,
+                isPropertyOnLeft: true, "Count", "ToList", enumerableType)
+            || ConversionComparisonHelper.TryMatchConversionPropertyComparison(
+                binary.RightOperand, binary.LeftOperand, binary.OperatorKind,
+                isPropertyOnLeft: false, "Count", "ToList", enumerableType))
         {
             context.ReportDiagnostic(Diagnostic.Create(Rule, binary.Syntax.GetLocation()));
         }
-    }
-
-    private static bool TryMatchToListCountComparison(
-        IOperation countSide,
-        IOperation constantSide,
-        BinaryOperatorKind operatorKind,
-        bool isCountOnLeft,
-        INamedTypeSymbol enumerableType)
-    {
-        if (countSide is not IPropertyReferenceOperation
-            {
-                Property.Name: "Count",
-                Instance: IInvocationOperation { TargetMethod: { Name: "ToList" } toListMethod }
-            }
-            || !SymbolEqualityComparer.Default.Equals(toListMethod.ContainingType, enumerableType))
-        {
-            return false;
-        }
-
-        if (constantSide is not ILiteralOperation { ConstantValue: { HasValue: true, Value: int constantValue } }
-            || constantValue is not (0 or 1))
-        {
-            return false;
-        }
-
-        return IsValidCountComparisonPattern(operatorKind, constantValue, isCountOnLeft);
-    }
-
-    private static bool IsValidCountComparisonPattern(
-        BinaryOperatorKind operatorKind,
-        int constantValue,
-        bool isCountOnLeft)
-    {
-        if (isCountOnLeft)
-        {
-            return operatorKind switch
-            {
-                // Existence patterns: > 0, >= 1, != 0
-                BinaryOperatorKind.GreaterThan when constantValue == 0 => true,
-                BinaryOperatorKind.GreaterThanOrEqual when constantValue == 1 => true,
-                BinaryOperatorKind.NotEquals when constantValue == 0 => true,
-                // Non-existence patterns: == 0, <= 0, < 1
-                BinaryOperatorKind.Equals when constantValue == 0 => true,
-                BinaryOperatorKind.LessThanOrEqual when constantValue == 0 => true,
-                BinaryOperatorKind.LessThan when constantValue == 1 => true,
-                _ => false
-            };
-        }
-
-        return operatorKind switch
-        {
-            // Existence patterns: 0 <, 1 <=, 0 !=
-            BinaryOperatorKind.LessThan when constantValue == 0 => true,
-            BinaryOperatorKind.LessThanOrEqual when constantValue == 1 => true,
-            BinaryOperatorKind.NotEquals when constantValue == 0 => true,
-            // Non-existence patterns: 0 ==, 0 >=, 1 >
-            BinaryOperatorKind.Equals when constantValue == 0 => true,
-            BinaryOperatorKind.GreaterThanOrEqual when constantValue == 0 => true,
-            BinaryOperatorKind.GreaterThan when constantValue == 1 => true,
-            _ => false
-        };
     }
 }

--- a/src/ToListinator.Analyzers/Utils/ConversionComparisonHelper.cs
+++ b/src/ToListinator.Analyzers/Utils/ConversionComparisonHelper.cs
@@ -1,0 +1,67 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace ToListinator.Analyzers.Utils;
+
+public static class ConversionComparisonHelper
+{
+    public static bool TryMatchConversionPropertyComparison(
+        IOperation propertySide,
+        IOperation constantSide,
+        BinaryOperatorKind operatorKind,
+        bool isPropertyOnLeft,
+        string propertyName,
+        string conversionMethodName,
+        INamedTypeSymbol enumerableType)
+    {
+        if (propertySide is not IPropertyReferenceOperation
+            {
+                Instance: IInvocationOperation { } invocation
+            } propertyRef
+            || propertyRef.Property.Name != propertyName
+            || invocation.TargetMethod.Name != conversionMethodName
+            || !SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, enumerableType))
+        {
+            return false;
+        }
+
+        if (constantSide is not ILiteralOperation { ConstantValue: { HasValue: true, Value: int constantValue } }
+            || constantValue is not (0 or 1))
+        {
+            return false;
+        }
+
+        return IsValidComparisonPattern(operatorKind, constantValue, isPropertyOnLeft);
+    }
+
+    public static bool IsValidComparisonPattern(
+        BinaryOperatorKind operatorKind,
+        int constantValue,
+        bool isPropertyOnLeft)
+    {
+        if (isPropertyOnLeft)
+        {
+            return operatorKind switch
+            {
+                BinaryOperatorKind.GreaterThan when constantValue == 0 => true,
+                BinaryOperatorKind.GreaterThanOrEqual when constantValue == 1 => true,
+                BinaryOperatorKind.NotEquals when constantValue == 0 => true,
+                BinaryOperatorKind.Equals when constantValue == 0 => true,
+                BinaryOperatorKind.LessThanOrEqual when constantValue == 0 => true,
+                BinaryOperatorKind.LessThan when constantValue == 1 => true,
+                _ => false
+            };
+        }
+
+        return operatorKind switch
+        {
+            BinaryOperatorKind.LessThan when constantValue == 0 => true,
+            BinaryOperatorKind.LessThanOrEqual when constantValue == 1 => true,
+            BinaryOperatorKind.NotEquals when constantValue == 0 => true,
+            BinaryOperatorKind.Equals when constantValue == 0 => true,
+            BinaryOperatorKind.GreaterThanOrEqual when constantValue == 0 => true,
+            BinaryOperatorKind.GreaterThan when constantValue == 1 => true,
+            _ => false
+        };
+    }
+}


### PR DESCRIPTION
Extracts the duplicated comparison pattern validation logic from ToListCountAnalyzer (TL003) and ToArrayLengthAnalyzer (TL011) into a shared ConversionComparisonHelper utility class.

Both analyzers had nearly identical implementations of TryMatch and IsValidComparisonPattern methods, differing only in the property name (Count vs Length) and conversion method name (ToList vs ToArray). The new helper parameterizes these values so both analyzers delegate to a single implementation.

Net result: -122 lines of duplicated code, +81 lines of shared code. All 367 tests pass.

Fixes #81
