### PR TITLE
Refactor NullCoalescingForeachAnalyzer to use RegisterCompilationStartAction

### DIFF
--- a/src/ToListinator.Analyzers/NullCoalescingForeachAnalyzer.cs
+++ b/src/ToListinator.Analyzers/NullCoalescingForeachAnalyzer.cs
@@ -24,10 +24,18 @@ public class NullCoalescingForeachAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
-        context.RegisterOperationAction(AnalyzeForEachLoop, OperationKind.Loop);
+        context.RegisterCompilationStartAction(startContext =>
+        {
+            var enumerableType = startContext.Compilation.GetTypeByMetadataName("System.Linq.Enumerable");
+            var arrayType = startContext.Compilation.GetTypeByMetadataName("System.Array");
+
+            startContext.RegisterOperationAction(
+                operationContext => AnalyzeForEachLoop(operationContext, enumerableType, arrayType),
+                OperationKind.Loop);
+        });
     }
 
-    private static void AnalyzeForEachLoop(OperationAnalysisContext context)
+    private static void AnalyzeForEachLoop(OperationAnalysisContext context, INamedTypeSymbol? enumerableType, INamedTypeSymbol? arrayType)
     {
         if (context.Operation is not IForEachLoopOperation forEachLoop)
         {
@@ -58,7 +66,7 @@ public class NullCoalescingForeachAnalyzer : DiagnosticAnalyzer
             fallback = fallbackConversion.Operand;
         }
 
-        if (!IsEmptyCollectionOperation(fallback))
+        if (!IsEmptyCollectionOperation(fallback, enumerableType, arrayType))
         {
             return;
         }
@@ -66,18 +74,17 @@ public class NullCoalescingForeachAnalyzer : DiagnosticAnalyzer
         context.ReportDiagnostic(Diagnostic.Create(Rule, coalesce.Syntax.GetLocation()));
     }
 
-    private static bool IsEmptyCollectionOperation(IOperation operation)
+    private static bool IsEmptyCollectionOperation(IOperation operation, INamedTypeSymbol? enumerableType, INamedTypeSymbol? arrayType)
     {
         return operation switch
         {
-            // new List<T>(), new HashSet<T>(), etc. with no arguments
             IObjectCreationOperation { Arguments.Length: 0 } => true,
 
-            // Array.Empty<T>() or Enumerable.Empty<T>()
-            IInvocationOperation { TargetMethod.Name: "Empty" } => true,
+            IInvocationOperation { TargetMethod: { Name: "Empty" } method } =>
+                (enumerableType is not null && SymbolEqualityComparer.Default.Equals(method.ContainingType, enumerableType))
+                || (arrayType is not null && SymbolEqualityComparer.Default.Equals(method.ContainingType, arrayType)),
 
-            // ImmutableArray<T>.Empty or similar static .Empty property
-            IPropertyReferenceOperation { Property.Name: "Empty", Instance: null } => true,
+            IPropertyReferenceOperation { Property: { Name: "Empty", IsStatic: true } } => true,
 
             // new T[0] or new T[] { }
             IArrayCreationOperation arrayCreation => IsEmptyArrayCreation(arrayCreation),

--- a/src/ToListinator.Analyzers/SingleElementAccessAnalyzer.cs
+++ b/src/ToListinator.Analyzers/SingleElementAccessAnalyzer.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 using System.Collections.Immutable;
+using ToListinator.Analyzers.Utils;
 
 namespace ToListinator.Analyzers;
 
@@ -62,7 +63,7 @@ public class SingleElementAccessAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        var innerInvocation = GetReceiverInvocation(invocation);
+        var innerInvocation = MethodChainHelper.GetReceiverInvocation(invocation);
 
         if (innerInvocation is null
             || innerInvocation.TargetMethod.Name is not ("ToList" or "ToArray")
@@ -76,42 +77,6 @@ public class SingleElementAccessAnalyzer : DiagnosticAnalyzer
 
         context.ReportDiagnostic(
             Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), properties.ToImmutable()));
-    }
-
-    private static IInvocationOperation? GetReceiverInvocation(IInvocationOperation invocation)
-    {
-        if (invocation.Instance is IInvocationOperation instanceInvocation)
-        {
-            return instanceInvocation;
-        }
-
-        // For extension methods called with dot syntax (e.g., items.ToList().First()),
-        // the receiver is passed as the first argument, potentially wrapped in a conversion.
-        // We exclude the static form (Enumerable.First(items.ToList())) by verifying
-        // the syntax receiver is an invocation, not a type name.
-        if (invocation.TargetMethod.IsExtensionMethod
-            && invocation.Arguments.Length > 0
-            && invocation.Syntax is InvocationExpressionSyntax
-               {
-                   Expression: MemberAccessExpressionSyntax
-                   {
-                       Expression: InvocationExpressionSyntax
-                   }
-               })
-        {
-            IOperation argValue = invocation.Arguments[0].Value;
-
-            // Roslyn may wrap the receiver in one or more implicit conversions
-            // (e.g. covariance, interface adaptation). Peel them all off.
-            while (argValue is IConversionOperation { IsImplicit: true } conversion)
-            {
-                argValue = conversion.Operand;
-            }
-
-            return argValue as IInvocationOperation;
-        }
-
-        return null;
     }
 
     private static void AnalyzePropertyReference(OperationAnalysisContext context, INamedTypeSymbol enumerableType)

--- a/src/ToListinator.Analyzers/Utils/MethodChainHelper.cs
+++ b/src/ToListinator.Analyzers/Utils/MethodChainHelper.cs
@@ -1,5 +1,6 @@
-using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -267,6 +268,43 @@ public static class MethodChainHelper
             {
                 break;
             }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves the receiver invocation of a method call in IOperation form, handling both
+    /// instance calls and extension methods called with dot syntax. Excludes the static form
+    /// (e.g., Enumerable.First(items.ToList())) by verifying the syntax receiver is an
+    /// invocation, not a type name. Peels implicit conversions that Roslyn may insert
+    /// (e.g., covariance, interface adaptation).
+    /// </summary>
+    public static IInvocationOperation? GetReceiverInvocation(IInvocationOperation invocation)
+    {
+        if (invocation.Instance is IInvocationOperation instanceInvocation)
+        {
+            return instanceInvocation;
+        }
+
+        if (invocation.TargetMethod.IsExtensionMethod
+            && invocation.Arguments.Length > 0
+            && invocation.Syntax is InvocationExpressionSyntax
+               {
+                   Expression: MemberAccessExpressionSyntax
+                   {
+                       Expression: InvocationExpressionSyntax
+                   }
+               })
+        {
+            IOperation argValue = invocation.Arguments[0].Value;
+
+            while (argValue is IConversionOperation { IsImplicit: true } conversion)
+            {
+                argValue = conversion.Operand;
+            }
+
+            return argValue as IInvocationOperation;
         }
 
         return null;

--- a/src/ToListinator.Analyzers/WhereCountAnalyzer.cs
+++ b/src/ToListinator.Analyzers/WhereCountAnalyzer.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
+using ToListinator.Analyzers.Utils;
 
 namespace ToListinator.Analyzers;
 
@@ -77,14 +78,14 @@ public class WhereCountAnalyzer : DiagnosticAnalyzer
         INamedTypeSymbol enumerableType)
     {
         var whereChain = new List<IInvocationOperation>();
-        var current = GetReceiverInvocation(startInvocation);
+        var current = MethodChainHelper.GetReceiverInvocation(startInvocation);
 
         while (current is not null
                && current.TargetMethod.Name is "Where"
                && SymbolEqualityComparer.Default.Equals(current.TargetMethod.ContainingType, enumerableType))
         {
             whereChain.Add(current);
-            current = GetReceiverInvocation(current);
+            current = MethodChainHelper.GetReceiverInvocation(current);
         }
 
         return whereChain;
@@ -102,38 +103,6 @@ public class WhereCountAnalyzer : DiagnosticAnalyzer
         }
 
         return IsValidPredicate(predicateExpression);
-    }
-
-    private static IInvocationOperation? GetReceiverInvocation(IInvocationOperation invocation)
-    {
-        if (invocation.Instance is IInvocationOperation instanceInvocation)
-        {
-            return instanceInvocation;
-        }
-
-        if (invocation.TargetMethod.IsExtensionMethod
-            && invocation.Arguments.Length > 0
-            && invocation.Syntax is InvocationExpressionSyntax
-               {
-                   Expression: MemberAccessExpressionSyntax
-                   {
-                       Expression: InvocationExpressionSyntax
-                   }
-               })
-        {
-            IOperation argValue = invocation.Arguments[0].Value;
-
-            // Roslyn may wrap the receiver in one or more implicit conversions
-            // (e.g. covariance, interface adaptation). Peel them all off.
-            while (argValue is IConversionOperation { IsImplicit: true } conversion)
-            {
-                argValue = conversion.Operand;
-            }
-
-            return argValue as IInvocationOperation;
-        }
-
-        return null;
     }
 
     private static bool IsValidPredicate(ExpressionSyntax expression)

--- a/test/ToListinator.TestApp/Program.cs
+++ b/test/ToListinator.TestApp/Program.cs
@@ -12,6 +12,12 @@ class Program
 
         var numbers = new[] { 1, 2, 3, 4, 5, 6 };
 
+        var resourceList = new List<string> { "Resource1", "Resource2", "Resource3" };
+
+        // Triggers TL002 - Remove unnecessary Select call
+        // Triggers TL007 - unnecessary ToList() in method chain
+        string resourceListString = string.Join("\n", resourceList.Select(x => x).ToList());
+
         // This should trigger TL007 - unnecessary ToList() in method chain
         var items = numbers.ToList().Select(x => x * 2).ToList();
 


### PR DESCRIPTION
Refactors NullCoalescingForeachAnalyzer to use RegisterCompilationStartAction, consistent with every other analyzer in the project. Resolves System.Linq.Enumerable and System.Array type symbols once at compilation start, then validates Empty method invocations via SymbolEqualityComparer instead of name-only checks. This eliminates potential false positives from unrelated methods named Empty while keeping all existing detection patterns intact. All 292 analyzer tests pass.

Fixes #86
